### PR TITLE
downgrade biome pre-commit to not use beta version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   hooks:
     - id: pyproject-fmt
 - repo: https://github.com/biomejs/pre-commit
-  rev: v2.0.0-beta.5
+  rev: v1.9.4
   hooks:
   - id: biome-format
 - repo: https://github.com/kynan/nbstripout


### PR DESCRIPTION
Currently failing, tried to apply migrate but did not seem to  respect the trailingCommas": "all" option. So downgrading seems the easiest way out of it. 

https://results.pre-commit.ci/run/github/899225754/1748283036.h23su9eMQ6uB7rxxYoBrOg

![image](https://github.com/user-attachments/assets/4fb7f627-b166-4efe-a059-4e870810e958)
