### PR TITLE
Exclude priority_keys from MM if unavailable

### DIFF
--- a/src/hv_anndata/manifoldmap.py
+++ b/src/hv_anndata/manifoldmap.py
@@ -435,7 +435,7 @@ class ManifoldMap(pn.viewable.Viewer):
         """Initialize the ManifoldMapApp with the given parameters."""
         super().__init__(**params)
         self._categorical = False
-        dr_options = [] 
+        dr_options = []
         available_keys = list(self.adata.obsm.keys())
         priority_keys = ("X_umap", "X_tsne", "X_pca")
         for key in priority_keys:

--- a/src/hv_anndata/manifoldmap.py
+++ b/src/hv_anndata/manifoldmap.py
@@ -435,9 +435,13 @@ class ManifoldMap(pn.viewable.Viewer):
         """Initialize the ManifoldMapApp with the given parameters."""
         super().__init__(**params)
         self._categorical = False
-        dr_options = []
+        dr_options = [] 
+        available_keys = list(self.adata.obsm.keys())
         priority_keys = ("X_umap", "X_tsne", "X_pca")
-        for key in priority_keys + tuple(self.adata.obsm.keys()):
+        for key in priority_keys:
+            if key in available_keys:
+                dr_options.append(key)
+        for key in available_keys:
             if key not in dr_options:
                 dr_options.append(key)
         self.param["reduction"].objects = dr_options


### PR DESCRIPTION
e.g. some datasets only have pca and umap but not tsne.. so tsne should not be included in the options