### PR TITLE
Dotmap with updated and renamed GeneSelector widget

### DIFF
--- a/docs/api/hv_anndata.AutoCompleteMultiChoice.rst
+++ b/docs/api/hv_anndata.AutoCompleteMultiChoice.rst
@@ -1,5 +1,0 @@
-``hv_anndata.AutoCompleteMultiChoice``
-======================================
-
-.. currentmodule:: hv_anndata
-.. autoclass:: AutoCompleteMultiChoice

--- a/docs/api/hv_anndata.GeneGroupSelector.rst
+++ b/docs/api/hv_anndata.GeneGroupSelector.rst
@@ -1,0 +1,5 @@
+``hv_anndata.GeneGroupSelector``
+======================================
+
+.. currentmodule:: hv_anndata
+.. autoclass:: GeneGroupSelector

--- a/docs/api/hv_anndata.GeneSelector.rst
+++ b/docs/api/hv_anndata.GeneSelector.rst
@@ -1,5 +1,5 @@
-``hv_anndata.GeneGroupSelector``
+``hv_anndata.GeneSelector``
 ======================================
 
 .. currentmodule:: hv_anndata
-.. autoclass:: GeneGroupSelector
+.. autoclass:: GeneSelector

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -11,7 +11,7 @@
    hv_anndata.AnnDataInterface
    hv_anndata.register
    hv_anndata.Dotmap
-   hv_anndata.GeneGroupSelector
+   hv_anndata.GeneSelector
    hv_anndata.ManifoldMap
    hv_anndata.ManifoldMapConfig
    hv_anndata.create_manifoldmap_plot

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,8 +10,8 @@
    hv_anndata.ACCESSOR
    hv_anndata.AnnDataInterface
    hv_anndata.register
-   hv_anndata.AutoCompleteMultiChoice
    hv_anndata.Dotmap
+   hv_anndata.GeneGroupSelector
    hv_anndata.ManifoldMap
    hv_anndata.ManifoldMapConfig
    hv_anndata.create_manifoldmap_plot

--- a/docs/index.ipynb
+++ b/docs/index.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dotmap plot configurable with the GeneGroupSelector widget"
+    "### Dotmap plot configurable with the GeneSelector widget"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Required for the GeneGroupSelector to render properly\n",
+    "# Required for the GeneSelector to render properly\n",
     "pn.extension(\"jsoneditor\")"
    ]
   },
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_autocompletemc = hv_anndata.GeneGroupSelector(options=options)"
+    "w_autocompletemc = hv_anndata.GeneSelector(options=options)"
    ]
   },
   {

--- a/docs/index.ipynb
+++ b/docs/index.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dotmap plot configurable with the AutoCompleteMultiChoice widget"
+    "### Dotmap plot configurable with the GeneGroupSelector widget"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Required for the AutoCompleteMultiChoice to render properly\n",
+    "# Required for the GeneGroupSelector to render properly\n",
     "pn.extension(\"jsoneditor\")"
    ]
   },
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "w_autocompletemc = hv_anndata.AutoCompleteMultiChoice(options=options)"
+    "w_autocompletemc = hv_anndata.GeneGroupSelector(options=options)"
    ]
   },
   {

--- a/src/hv_anndata/__init__.py
+++ b/src/hv_anndata/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .components import GeneGroupSelector
+from .components import GeneSelector
 from .interface import ACCESSOR as _A
 from .interface import AnnDataInterface, register
 from .manifoldmap import ManifoldMap, ManifoldMapConfig, create_manifoldmap_plot
@@ -20,7 +20,7 @@ __all__ = [
     "ACCESSOR",
     "AnnDataInterface",
     "Dotmap",
-    "GeneGroupSelector",
+    "GeneSelector",
     "ManifoldMap",
     "ManifoldMapConfig",
     "create_manifoldmap_plot",

--- a/src/hv_anndata/__init__.py
+++ b/src/hv_anndata/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .components import AutoCompleteMultiChoice
+from .components import GeneGroupSelector
 from .interface import ACCESSOR as _A
 from .interface import AnnDataInterface, register
 from .manifoldmap import ManifoldMap, ManifoldMapConfig, create_manifoldmap_plot
@@ -19,8 +19,8 @@ ACCESSOR = _A
 __all__ = [
     "ACCESSOR",
     "AnnDataInterface",
-    "AutoCompleteMultiChoice",
     "Dotmap",
+    "GeneGroupSelector",
     "ManifoldMap",
     "ManifoldMapConfig",
     "create_manifoldmap_plot",

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -10,18 +10,23 @@ from panel.widgets.base import WidgetBase
 
 
 class GeneGroupSelector(WidgetBase, PyComponent):
-    """A composite component combining a text input with a MultiChoice widget.
+    """A custom Panel widget for managing groups of marker genes.
 
-    The text input serves as a key for a dictionary where each key maps to a
-    list of selected values.
+    This component allows users to create, update, and manage groups of
+    marker genes through a composite interactive widget.
+
+    - Add new groups (keys) and associate them with marker genes (values).
+    - Select and modify marker genes for a specific group using a MultiChoice
+      widget.
+    - View and edit the entire group-to-marker mapping in a JSON editor widget.
     """
 
     value: dict[str, list[str]] = param.Dict(  # type: ignore[assignment]
-        default={}, doc="Dictionary mapping keys to lists of selected values"
+        default={}, doc="Dictionary mapping groups to lists of marker genes."
     )
 
     options: list[str] = param.List(  # type: ignore[assignment]
-        default=[], doc="List of available options for the MultiChoice"
+        default=[], doc="List of available marker genes for the MultiChoice."
     )
 
     width = param.Integer(  # type: ignore[assignment]
@@ -32,15 +37,15 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         default="",
         objects=[],
         check_on_set=False,
-        doc="Current value of the text input (key)",
+        doc="Current value of the text input (group)",
     )
 
     _input_value: str = param.String(  # type: ignore[assignment]
-        default="", doc="Current value of the text input (value)"
+        default="", doc="Current value of the text input (marker gene)"
     )
 
     _current_selection: list[str] = param.List(  # type: ignore[assignment]
-        default=[], doc="Current selection for the active key"
+        default=[], doc="Current selection of marker genes for the active group"
     )
 
     def __init__(self, **params: object) -> None:
@@ -52,8 +57,8 @@ class GeneGroupSelector(WidgetBase, PyComponent):
 
         self.w_key_input = pmui.AutocompleteInput.from_param(
             self.param._input_key,  # noqa: SLF001
-            name="Group Key",
-            placeholder="Enter/select key name",
+            name="Active group",
+            placeholder="Enter/select group name",
             restrict=False,
             min_characters=0,
             description="",
@@ -62,7 +67,7 @@ class GeneGroupSelector(WidgetBase, PyComponent):
 
         self.w_value_input = pmui.TextInput.from_param(
             self.param._input_value,  # noqa: SLF001
-            name="Add new value to group",
+            name="Add new marker gene to group",
             disabled=self.param._input_key.rx().rx.bool().rx.not_(),  # noqa: SLF001
             description="",
             sizing_mode="stretch_width",
@@ -71,7 +76,7 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         self.w_multi_choice = pmui.MultiChoice.from_param(
             self.param._current_selection,  # noqa: SLF001
             options=self.param.options,
-            name="Values for the selected group",
+            name="Marker genes for the selected group",
             searchable=True,
             disabled=self.w_value_input.param.disabled,
             description="",
@@ -80,7 +85,6 @@ class GeneGroupSelector(WidgetBase, PyComponent):
 
         self.w_json_editor = pn.widgets.JSONEditor.from_param(
             self.param.value,
-            name="JSON Editor",
             mode="tree",
             menu=False,
             sizing_mode="stretch_width",
@@ -139,5 +143,8 @@ class GeneGroupSelector(WidgetBase, PyComponent):
             self.w_key_input,
             self.w_value_input,
             self.w_multi_choice,
+            pmui.Typography(
+                "JSON Editor:", variant="caption", color="primary", margin=(0, 10)
+            ),
             self.w_json_editor,
         )

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from itertools import chain
+
 import panel as pn
 import panel_material_ui as pmui
 import param
@@ -22,7 +24,9 @@ class GeneGroupSelector(WidgetBase, PyComponent):
     """
 
     value: dict[str, list[str]] = param.Dict(  # type: ignore[assignment]
-        default={}, doc="Dictionary mapping groups to lists of marker genes."
+        default={},
+        doc="Dictionary mapping groups to lists of marker genes.",
+        allow_refs=True,
     )
 
     options: list[str] = param.List(  # type: ignore[assignment]
@@ -54,6 +58,10 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         self._current_key = ""
         if self.value:
             self.param._input_key.objects = list(self.value)  # noqa: SLF001
+            if not self.options:
+                self.options = list(
+                    dict.fromkeys(chain.from_iterable(self.value.values()))
+                )
 
         self.w_key_input = pmui.AutocompleteInput.from_param(
             self.param._input_key,  # noqa: SLF001

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -108,12 +108,18 @@ class GeneSelector(WidgetBase, PyComponent):
             sizing_mode="stretch_width",
         )
 
-        self.w_json_editor = pn.widgets.JSONEditor.from_param(
-            self.param.value,
+        self.w_json_editor = pn.widgets.JSONEditor(
             mode="tree",
             menu=False,
             sizing_mode="stretch_width",
         )
+        # Custom syncing with onlychanged=False to detect when a dict is
+        # reordered in the JSONEditor.
+        self.param.watch(self._on_value, "value")
+        self.w_json_editor.param.watch(
+            self._on_json_editor_value, "value", onlychanged=False
+        )
+        self.w_json_editor.value = self.value
 
         self._current_key = ""
         if self.value:
@@ -129,6 +135,12 @@ class GeneSelector(WidgetBase, PyComponent):
                 if not self.options:
                     self.options = self.value
                 self._current_selection = self.value
+
+    def _on_value(self, event: param.parameterized.Event) -> None:
+        self.w_json_editor.value = event.new
+
+    def _on_json_editor_value(self, event: param.parameterized.Event) -> None:
+        self.value = event.new
 
     @param.depends("_input_key", watch=True)
     def _handle_key_input(self) -> None:

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -60,13 +60,9 @@ class GeneGroupSelector(WidgetBase, PyComponent):
             sizing_mode="stretch_width",
         )
 
-        self.w_value_input = pmui.AutocompleteInput.from_param(
+        self.w_value_input = pmui.TextInput.from_param(
             self.param._input_value,  # noqa: SLF001
-            options=self.param.options,
-            placeholder="Enter/select value",
-            name="Available values",
-            restrict=False,
-            min_characters=0,
+            name="Add new value to group",
             disabled=self.param._input_key.rx().rx.bool().rx.not_(),  # noqa: SLF001
             description="",
             sizing_mode="stretch_width",

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -11,16 +11,25 @@ from panel.custom import PyComponent
 from panel.widgets.base import WidgetBase
 
 
-class GeneGroupSelector(WidgetBase, PyComponent):
-    """A custom Panel widget for managing groups of marker genes.
+class GeneSelector(WidgetBase, PyComponent):
+    """A custom Panel widget for managing and selecting marker genes.
 
     This component allows users to create, update, and manage groups of
     marker genes through a composite interactive widget.
 
     - Add new groups (keys) and associate them with marker genes (values).
+    - Add marker genes to the list of available options.
     - Select and modify marker genes for a specific group using a MultiChoice
       widget.
     - View and edit the entire group-to-marker mapping in a JSON editor widget.
+
+    This component also allows users to create and update a list of marker
+    genes:
+
+    - Add marker genes to the list of available options.
+    - Select the  marker genes that constitue the list.
+    - View and edit the list in a JSON editor widget.
+
     """
 
     value: dict[str, list[str]] | list[str] = param.ClassSelector(  # type: ignore[assignment]

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -9,7 +9,7 @@ from panel.custom import PyComponent
 from panel.widgets.base import WidgetBase
 
 
-class AutoCompleteMultiChoice(WidgetBase, PyComponent):
+class GeneGroupSelector(WidgetBase, PyComponent):
     """A composite component combining a text input with a MultiChoice widget.
 
     The text input serves as a key for a dictionary where each key maps to a

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -50,7 +50,7 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         if self.value:
             self.param._input_key.objects = list(self.value)  # noqa: SLF001
 
-        self._key_input = pmui.AutocompleteInput.from_param(
+        self.w_key_input = pmui.AutocompleteInput.from_param(
             self.param._input_key,  # noqa: SLF001
             name="Group Key",
             placeholder="Enter/select key name",
@@ -60,7 +60,7 @@ class GeneGroupSelector(WidgetBase, PyComponent):
             sizing_mode="stretch_width",
         )
 
-        self._value_input = pmui.AutocompleteInput.from_param(
+        self.w_value_input = pmui.AutocompleteInput.from_param(
             self.param._input_value,  # noqa: SLF001
             options=self.param.options,
             placeholder="Enter/select value",
@@ -72,17 +72,17 @@ class GeneGroupSelector(WidgetBase, PyComponent):
             sizing_mode="stretch_width",
         )
 
-        self._multi_choice = pmui.MultiChoice.from_param(
+        self.w_multi_choice = pmui.MultiChoice.from_param(
             self.param._current_selection,  # noqa: SLF001
             options=self.param.options,
             name="Values for the selected group",
             searchable=True,
-            disabled=self._value_input.param.disabled,
+            disabled=self.w_value_input.param.disabled,
             description="",
             sizing_mode="stretch_width",
         )
 
-        self._json_editor = pn.widgets.JSONEditor.from_param(
+        self.w_json_editor = pn.widgets.JSONEditor.from_param(
             self.param.value,
             name="JSON Editor",
             mode="tree",
@@ -108,8 +108,8 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         # Update current selection to match the key's current values
         self._current_selection = list(self.value.get(key, []))
 
-        if key not in self._key_input.options:
-            self._key_input.options = [*self._key_input.options, key]
+        if key not in self.w_key_input.options:
+            self.w_key_input.options = [*self.w_key_input.options, key]
 
     @param.depends("_input_value", watch=True)
     def _handle_value_input(self) -> None:
@@ -125,7 +125,7 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         if value not in self._current_selection:
             self._current_selection = [*self._current_selection, value]
 
-        self._value_input.value = ""
+        self.w_value_input.value = ""
 
     @param.depends("_current_selection", watch=True)
     def _handle_selection_change(self) -> None:
@@ -140,8 +140,8 @@ class GeneGroupSelector(WidgetBase, PyComponent):
 
     def __panel__(self) -> pn.layout.Column:
         return pn.Column(
-            self._key_input,
-            self._value_input,
-            self._multi_choice,
-            self._json_editor,
+            self.w_key_input,
+            self.w_value_input,
+            self.w_multi_choice,
+            self.w_json_editor,
         )

--- a/src/hv_anndata/components.py
+++ b/src/hv_anndata/components.py
@@ -28,8 +28,11 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         default=300, allow_None=True, doc="Width of this component."
     )
 
-    _input_key: str = param.String(  # type: ignore[assignment]
-        default="", doc="Current value of the text input (key)"
+    _input_key: str = param.Selector(  # type: ignore[assignment]
+        default="",
+        objects=[],
+        check_on_set=False,
+        doc="Current value of the text input (key)",
     )
 
     _input_value: str = param.String(  # type: ignore[assignment]
@@ -44,6 +47,8 @@ class GeneGroupSelector(WidgetBase, PyComponent):
         """Initialize the component with the given parameters."""
         super().__init__(**params)
         self._current_key = ""
+        if self.value:
+            self.param._input_key.objects = list(self.value)  # noqa: SLF001
 
         self._key_input = pmui.AutocompleteInput.from_param(
             self.param._input_key,  # noqa: SLF001

--- a/src/hv_anndata/plotting.py
+++ b/src/hv_anndata/plotting.py
@@ -13,7 +13,7 @@ import panel as pn
 import param
 from packaging.version import Version
 
-from .components import GeneGroupSelector
+from .components import GeneSelector
 
 _HOLOVIEWS_VERSION = Version(hv.__version__).release
 
@@ -291,7 +291,7 @@ class Dotmap(pn.viewable.Viewer):
             msg = f"Needs to have the following argument(s): {required}"
             raise TypeError(msg)
         super().__init__(**params)
-        self._widget = GeneGroupSelector(value=self.param.marker_genes)
+        self._widget = GeneSelector(value=self.param.marker_genes)
         self._widget.param.watch(self._update_marker_genes, "value")
 
     def _update_marker_genes(self, event: param.parameterized.Event) -> None:

--- a/src/hv_anndata/plotting.py
+++ b/src/hv_anndata/plotting.py
@@ -9,8 +9,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 import anndata as ad
 import holoviews as hv
 import pandas as pd
+import panel as pn
 import param
 from packaging.version import Version
+
+from .components import GeneGroupSelector
 
 _HOLOVIEWS_VERSION = Version(hv.__version__).release
 
@@ -31,7 +34,7 @@ class _DotmapPlotParams(TypedDict):
     mean_only_expressed: NotRequired[bool]
 
 
-class Dotmap(param.ParameterizedFunction):
+class Dotmap(pn.viewable.Viewer):
     """Create a DotmapPlot from anndata."""
 
     kdims = param.List(
@@ -91,27 +94,27 @@ class Dotmap(param.ParameterizedFunction):
 
     def _prepare_data(self) -> pd.DataFrame:  # noqa: C901, PLR0912, PLR0915
         # Flatten the marker_genes preserving order
-        is_mapping_marker_genes = isinstance(self.p.marker_genes, Mapping)
+        is_mapping_marker_genes = isinstance(self.marker_genes, Mapping)
         if is_mapping_marker_genes:
             all_marker_genes = list(
-                dict.fromkeys(chain.from_iterable(self.p.marker_genes.values()))
+                dict.fromkeys(chain.from_iterable(self.marker_genes.values()))
             )
         else:
-            all_marker_genes = list(self.p.marker_genes)
+            all_marker_genes = list(self.marker_genes)
 
         # Determine to use raw or processed
-        use_raw = self.p.use_raw
+        use_raw = self.use_raw
         if use_raw is None:
-            use_raw = self.p.adata.raw is not None
-        elif use_raw and self.p.adata.raw is None:
+            use_raw = self.adata.raw is not None
+        elif use_raw and self.adata.raw is None:
             err = "use_raw=True but .raw attribute is not present in adata"
             raise ValueError(err)
 
         # Check which genes are actually present in the correct location
-        if use_raw and self.p.adata.raw is not None:
-            available_var_names = self.p.adata.raw.var_names
+        if use_raw and self.adata.raw is not None:
+            available_var_names = self.adata.raw.var_names
         else:
-            available_var_names = self.p.adata.var_names
+            available_var_names = self.adata.var_names
 
         missing_genes = set(all_marker_genes) - set(available_var_names)
         if missing_genes:
@@ -128,34 +131,34 @@ class Dotmap(param.ParameterizedFunction):
             available_marker_genes = all_marker_genes
 
         # Subset the data with only available genes
-        if use_raw and self.p.adata.raw is not None:
-            adata_subset = self.p.adata.raw[:, available_marker_genes]
+        if use_raw and self.adata.raw is not None:
+            adata_subset = self.adata.raw[:, available_marker_genes]
             expression_df = pd.DataFrame(
                 adata_subset.X.toarray()
                 if hasattr(adata_subset.X, "toarray")
                 else adata_subset.X,
-                index=self.p.adata.obs_names,
+                index=self.adata.obs_names,
                 columns=available_marker_genes,
             )
         else:
-            expression_df = self.p.adata[:, available_marker_genes].to_df()
+            expression_df = self.adata[:, available_marker_genes].to_df()
 
         # Join with groupby column
-        joined_df = expression_df.join(self.p.adata.obs[self.p.groupby])
+        joined_df = expression_df.join(self.adata.obs[self.groupby])
 
         def compute_expression(df: pd.DataFrame) -> pd.DataFrame:
             # Separate the groupby column from gene columns
-            gene_cols = [col for col in df.columns if col != self.p.groupby]
+            gene_cols = [col for col in df.columns if col != self.groupby]
 
             results = {}
             for gene in gene_cols:
                 gene_data = df[gene]
 
                 # percentage of expressing cells
-                percentage = (gene_data > self.p.expression_cutoff).mean() * 100
+                percentage = (gene_data > self.expression_cutoff).mean() * 100
 
-                if self.p.mean_only_expressed:
-                    expressing_mask = gene_data > self.p.expression_cutoff
+                if self.mean_only_expressed:
+                    expressing_mask = gene_data > self.expression_cutoff
                     if expressing_mask.any():
                         mean_expr = gene_data[expressing_mask].mean()
                     else:
@@ -167,7 +170,7 @@ class Dotmap(param.ParameterizedFunction):
 
             return pd.DataFrame(results).T
 
-        grouped = joined_df.groupby(self.p.groupby, observed=True)
+        grouped = joined_df.groupby(self.groupby, observed=True)
         expression_stats = grouped.apply(compute_expression, include_groups=False)
 
         if is_mapping_marker_genes:
@@ -178,7 +181,7 @@ class Dotmap(param.ParameterizedFunction):
                     marker_cluster_name=marker_cluster_name,
                     gene_id=gene,
                 )
-                for marker_cluster_name, gene_list in self.p.marker_genes.items()
+                for marker_cluster_name, gene_list in self.marker_genes.items()
                 for gene in gene_list
                 # Only include genes that weren't filtered out
                 if gene in available_marker_genes
@@ -188,7 +191,7 @@ class Dotmap(param.ParameterizedFunction):
                 expression_stats.xs(gene, level=1)
                 .reset_index(names="cluster")
                 .assign(gene_id=gene)
-                for gene in self.p.marker_genes
+                for gene in self.marker_genes
                 # Only include genes that weren't filtered out
                 if gene in available_marker_genes
             ]
@@ -196,10 +199,10 @@ class Dotmap(param.ParameterizedFunction):
         if data:
             df = pd.concat(data, ignore_index=True)
         else:
-            df = pd.DataFrame({k: [] for k in self.p.kdims + self.p.vdims})
+            df = pd.DataFrame({k: [] for k in self.kdims + self.vdims})
 
         # Apply standard_scale if specified
-        if self.p.standard_scale == "var":
+        if self.standard_scale == "var":
             # Normalize each gene across all cell types
             for gene in df["gene_id"].unique():
                 mask = df["gene_id"] == gene
@@ -213,7 +216,7 @@ class Dotmap(param.ParameterizedFunction):
                 else:
                     df.loc[mask, "mean_expression"] = 0.0
 
-        elif self.p.standard_scale == "group":
+        elif self.standard_scale == "group":
             # Normalize each cell type across all genes
             for cluster in df["cluster"].unique():
                 mask = df["cluster"] == cluster
@@ -250,11 +253,11 @@ class Dotmap(param.ParameterizedFunction):
         radius_dim = hv.dim("percentage").norm()
         match hv.Store.current_backend:
             case "matplotlib":
-                backend_opts = {"s": radius_dim * self.p.max_dot_size}
+                backend_opts = {"s": radius_dim * self.max_dot_size}
             case "bokeh":
-                hover_tooltips = [*self.p.kdims, *self.p.vdims]
+                hover_tooltips = [*self.kdims, *self.vdims]
                 if "marker_cluster_name" in hover_tooltips and (
-                    not isinstance(self.p.marker_genes, Mapping)
+                    not isinstance(self.marker_genes, Mapping)
                 ):
                     hover_tooltips.remove("marker_cluster_name")
                 backend_opts = {
@@ -269,20 +272,30 @@ class Dotmap(param.ParameterizedFunction):
                 if _HOLOVIEWS_VERSION >= (1, 21, 0):
                     backend_opts |= {"radius": radius_dim / 2}
                 else:
-                    backend_opts |= {"size": radius_dim * self.p.max_dot_size}
+                    backend_opts |= {"size": radius_dim * self.max_dot_size}
             case _:
                 backend_opts = {}
 
         return opts | backend_opts
 
-    def __call__(self, **params: Unpack[_DotmapPlotParams]) -> hv.Points:
-        """Create a DotmapPlot from anndata."""
+    @param.depends("marker_genes")
+    def _plot_view(self) -> hv.Points:
+        df = self._prepare_data()
+        plot = hv.Points(df, kdims=self.kdims, vdims=self.vdims)
+        plot.opts(**self._get_opts())
+        return plot
+
+    def __init__(self, **params: Unpack[_DotmapPlotParams]) -> None:
+        """Init the Dotmap."""
         if required := {"adata", "marker_genes", "groupby"} - params.keys():
             msg = f"Needs to have the following argument(s): {required}"
             raise TypeError(msg)
-        self.p = param.ParamOverrides(self, params)
+        super().__init__(**params)
+        self._widget = GeneGroupSelector(value=self.param.marker_genes)
+        self._widget.param.watch(self._update_marker_genes, "value")
 
-        df = self._prepare_data()
-        plot = hv.Points(df, kdims=self.p.kdims, vdims=self.p.vdims)
-        plot.opts(**self._get_opts())
-        return plot
+    def _update_marker_genes(self, event: param.parameterized.Event) -> None:
+        self.marker_genes = event.new
+
+    def __panel__(self) -> pn.viewable.Viewable:
+        return pn.Row(self._widget, self._plot_view)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -22,11 +22,11 @@ def test_autocomplete_multichoice_new_groups() -> None:
 
     w._key_input.value = "a"
     assert w.value == {"a": []}
-    assert w._key_input.options == ["a"]
+    assert w._key_input.options == ["", "a"]
 
     w._key_input.value = "b"
     assert w.value == {"a": [], "b": []}
-    assert w._key_input.options == ["a", "b"]
+    assert w._key_input.options == ["", "a", "b"]
 
 
 def test_autocomplete_multichoice_new_values() -> None:
@@ -59,3 +59,10 @@ def test_autocomplete_multichoice_update_selected() -> None:
     w._multi_choice.value = ["1"]
 
     assert w.value == {"a": ["1"]}
+
+
+def test_autocomplete_multichoice_value_init_key_options() -> None:
+    w = GeneGroupSelector(value={"a": ["1", "2"]})
+
+    assert w.param._input_key.objects == ["a"]
+    assert list(w._key_input.options) == ["a"]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -20,43 +20,43 @@ def test_autocomplete_multichoice_init_options() -> None:
 def test_autocomplete_multichoice_new_groups() -> None:
     w = GeneGroupSelector()
 
-    w._key_input.value = "a"
+    w.w_key_input.value = "a"
     assert w.value == {"a": []}
-    assert w._key_input.options == ["", "a"]
+    assert w.w_key_input.options == ["", "a"]
 
-    w._key_input.value = "b"
+    w.w_key_input.value = "b"
     assert w.value == {"a": [], "b": []}
-    assert w._key_input.options == ["", "a", "b"]
+    assert w.w_key_input.options == ["", "a", "b"]
 
 
 def test_autocomplete_multichoice_new_values() -> None:
     w = GeneGroupSelector()
 
-    w._key_input.value = "a"
+    w.w_key_input.value = "a"
 
-    w._value_input.value = "1"
+    w.w_value_input.value = "1"
 
     assert w.options == ["1"]
-    assert w._multi_choice.value == ["1"]
-    assert w._value_input.value == ""
+    assert w.w_multi_choice.value == ["1"]
+    assert w.w_value_input.value == ""
     assert w.value == {"a": ["1"]}
 
-    w._value_input.value = "2"
+    w.w_value_input.value = "2"
 
     assert w.options == ["1", "2"]
-    assert w._multi_choice.value == ["1", "2"]
-    assert w._value_input.value == ""
+    assert w.w_multi_choice.value == ["1", "2"]
+    assert w.w_value_input.value == ""
     assert w.value == {"a": ["1", "2"]}
 
 
 def test_autocomplete_multichoice_update_selected() -> None:
     w = GeneGroupSelector(value={"a": ["1", "2"]})
 
-    w._key_input.value = "a"
-    assert w._multi_choice.value == ["1", "2"]
+    w.w_key_input.value = "a"
+    assert w.w_multi_choice.value == ["1", "2"]
     assert w.value == {"a": ["1", "2"]}
 
-    w._multi_choice.value = ["1"]
+    w.w_multi_choice.value = ["1"]
 
     assert w.value == {"a": ["1"]}
 
@@ -65,4 +65,4 @@ def test_autocomplete_multichoice_value_init_key_options() -> None:
     w = GeneGroupSelector(value={"a": ["1", "2"]})
 
     assert w.param._input_key.objects == ["a"]
-    assert list(w._key_input.options) == ["a"]
+    assert list(w.w_key_input.options) == ["a"]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -4,24 +4,24 @@ from __future__ import annotations
 
 import pytest
 
-from hv_anndata.components import GeneGroupSelector
+from hv_anndata.components import GeneSelector
 
 
 def test_autocomplete_multichoice_init() -> None:
-    GeneGroupSelector()
+    GeneSelector()
 
 
 @pytest.mark.parametrize("value", [{"a": ["1", "2"]}, ["1", "2"]])
 def test_autocomplete_multichoice_init_value(value: list | dict) -> None:
-    GeneGroupSelector(value=value)
+    GeneSelector(value=value)
 
 
 def test_autocomplete_multichoice_init_options() -> None:
-    GeneGroupSelector(options=["1", "2"])
+    GeneSelector(options=["1", "2"])
 
 
 def test_autocomplete_multichoice_dict_new_groups() -> None:
-    w = GeneGroupSelector()
+    w = GeneSelector()
 
     w.w_key_input.value = "a"
     assert w.value == {"a": []}
@@ -33,7 +33,7 @@ def test_autocomplete_multichoice_dict_new_groups() -> None:
 
 
 def test_autocomplete_multichoice_dict_new_values() -> None:
-    w = GeneGroupSelector()
+    w = GeneSelector()
 
     w.w_key_input.value = "a"
 
@@ -53,7 +53,7 @@ def test_autocomplete_multichoice_dict_new_values() -> None:
 
 
 def test_autocomplete_multichoice_list_new_values() -> None:
-    w = GeneGroupSelector(value=[])
+    w = GeneSelector(value=[])
 
     w.w_value_input.value = "1"
 
@@ -71,7 +71,7 @@ def test_autocomplete_multichoice_list_new_values() -> None:
 
 
 def test_autocomplete_multichoice_dict_update_selected() -> None:
-    w = GeneGroupSelector(value={"a": ["1", "2"]})
+    w = GeneSelector(value={"a": ["1", "2"]})
 
     w.w_key_input.value = "a"
     assert w.w_multi_choice.value == ["1", "2"]
@@ -83,7 +83,7 @@ def test_autocomplete_multichoice_dict_update_selected() -> None:
 
 
 def test_autocomplete_multichoice_list_update_selected() -> None:
-    w = GeneGroupSelector(value=["1", "2"])
+    w = GeneSelector(value=["1", "2"])
 
     w.w_multi_choice.value = ["1"]
 
@@ -91,14 +91,14 @@ def test_autocomplete_multichoice_list_update_selected() -> None:
 
 
 def test_autocomplete_multichoice_dict_value_init_key_options() -> None:
-    w = GeneGroupSelector(value={"a": ["1", "2"]})
+    w = GeneSelector(value={"a": ["1", "2"]})
 
     assert w.param._input_key.objects == ["a"]
     assert w.w_key_input.options == {"a": "a"}
 
 
 def test_autocomplete_multichoice_list_value_init_mc() -> None:
-    w = GeneGroupSelector(value=["1", "2"])
+    w = GeneSelector(value=["1", "2"])
 
     assert w._current_selection == ["1", "2"]
     assert w.w_multi_choice.value == ["1", "2"]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,23 +2,23 @@
 
 from __future__ import annotations
 
-from hv_anndata.components import AutoCompleteMultiChoice
+from hv_anndata.components import GeneGroupSelector
 
 
 def test_autocomplete_multichoice_init() -> None:
-    AutoCompleteMultiChoice()
+    GeneGroupSelector()
 
 
 def test_autocomplete_multichoice_init_value() -> None:
-    AutoCompleteMultiChoice(value={"a": ["1", "2"]})
+    GeneGroupSelector(value={"a": ["1", "2"]})
 
 
 def test_autocomplete_multichoice_init_options() -> None:
-    AutoCompleteMultiChoice(options=["1", "2"])
+    GeneGroupSelector(options=["1", "2"])
 
 
 def test_autocomplete_multichoice_new_groups() -> None:
-    w = AutoCompleteMultiChoice()
+    w = GeneGroupSelector()
 
     w._key_input.value = "a"
     assert w.value == {"a": []}
@@ -30,7 +30,7 @@ def test_autocomplete_multichoice_new_groups() -> None:
 
 
 def test_autocomplete_multichoice_new_values() -> None:
-    w = AutoCompleteMultiChoice()
+    w = GeneGroupSelector()
 
     w._key_input.value = "a"
 
@@ -50,7 +50,7 @@ def test_autocomplete_multichoice_new_values() -> None:
 
 
 def test_autocomplete_multichoice_update_selected() -> None:
-    w = AutoCompleteMultiChoice(value={"a": ["1", "2"]})
+    w = GeneGroupSelector(value={"a": ["1", "2"]})
 
     w._key_input.value = "a"
     assert w._multi_choice.value == ["1", "2"]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hv_anndata.components import GeneGroupSelector
 
 
@@ -9,15 +11,16 @@ def test_autocomplete_multichoice_init() -> None:
     GeneGroupSelector()
 
 
-def test_autocomplete_multichoice_init_value() -> None:
-    GeneGroupSelector(value={"a": ["1", "2"]})
+@pytest.mark.parametrize("value", [{"a": ["1", "2"]}, ["1", "2"]])
+def test_autocomplete_multichoice_init_value(value: list | dict) -> None:
+    GeneGroupSelector(value=value)
 
 
 def test_autocomplete_multichoice_init_options() -> None:
     GeneGroupSelector(options=["1", "2"])
 
 
-def test_autocomplete_multichoice_new_groups() -> None:
+def test_autocomplete_multichoice_dict_new_groups() -> None:
     w = GeneGroupSelector()
 
     w.w_key_input.value = "a"
@@ -29,7 +32,7 @@ def test_autocomplete_multichoice_new_groups() -> None:
     assert w.w_key_input.options == ["", "a", "b"]
 
 
-def test_autocomplete_multichoice_new_values() -> None:
+def test_autocomplete_multichoice_dict_new_values() -> None:
     w = GeneGroupSelector()
 
     w.w_key_input.value = "a"
@@ -49,7 +52,25 @@ def test_autocomplete_multichoice_new_values() -> None:
     assert w.value == {"a": ["1", "2"]}
 
 
-def test_autocomplete_multichoice_update_selected() -> None:
+def test_autocomplete_multichoice_list_new_values() -> None:
+    w = GeneGroupSelector(value=[])
+
+    w.w_value_input.value = "1"
+
+    assert w.options == ["1"]
+    assert w.w_multi_choice.value == ["1"]
+    assert w.w_value_input.value == ""
+    assert w.value == ["1"]
+
+    w.w_value_input.value = "2"
+
+    assert w.options == ["1", "2"]
+    assert w.w_multi_choice.value == ["1", "2"]
+    assert w.w_value_input.value == ""
+    assert w.value == ["1", "2"]
+
+
+def test_autocomplete_multichoice_dict_update_selected() -> None:
     w = GeneGroupSelector(value={"a": ["1", "2"]})
 
     w.w_key_input.value = "a"
@@ -61,8 +82,24 @@ def test_autocomplete_multichoice_update_selected() -> None:
     assert w.value == {"a": ["1"]}
 
 
-def test_autocomplete_multichoice_value_init_key_options() -> None:
+def test_autocomplete_multichoice_list_update_selected() -> None:
+    w = GeneGroupSelector(value=["1", "2"])
+
+    w.w_multi_choice.value = ["1"]
+
+    assert w.value == ["1"]
+
+
+def test_autocomplete_multichoice_dict_value_init_key_options() -> None:
     w = GeneGroupSelector(value={"a": ["1", "2"]})
 
     assert w.param._input_key.objects == ["a"]
-    assert list(w.w_key_input.options) == ["a"]
+    assert w.w_key_input.options == {"a": "a"}
+
+
+def test_autocomplete_multichoice_list_value_init_mc() -> None:
+    w = GeneGroupSelector(value=["1", "2"])
+
+    assert w._current_selection == ["1", "2"]
+    assert w.w_multi_choice.value == ["1", "2"]
+    assert w.w_multi_choice.options == ["1", "2"]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -21,9 +21,10 @@ def test_dotmap_bokeh(marker_func: Callable) -> None:
     adata = sc.datasets.pbmc68k_reduced()
     markers = ["C1QA", "PSAP", "CD79A", "CD79B", "CST3", "LYZ"]
 
-    dotmap = Dotmap(
+    dotmap_layout = Dotmap(
         adata=adata, marker_genes=marker_func(markers), groupby="bulk_labels"
     )
+    dotmap = dotmap_layout._plot_view()
 
     assert isinstance(dotmap.data, pd.DataFrame)
     assert dotmap.data.shape == (60, 6)
@@ -47,9 +48,10 @@ def test_dotmap_mpl(marker_func: Callable) -> None:
     adata = sc.datasets.pbmc68k_reduced()
     markers = ["C1QA", "PSAP", "CD79A", "CD79B", "CST3", "LYZ"]
 
-    dotmap = Dotmap(
+    dotmap_layout = Dotmap(
         adata=adata, marker_genes=marker_func(markers), groupby="bulk_labels"
     )
+    dotmap = dotmap_layout._plot_view()
 
     assert isinstance(dotmap.data, pd.DataFrame)
     assert dotmap.data.shape == (60, 6)
@@ -73,15 +75,16 @@ def test_dotmap_use_raw_explicit_bokeh() -> None:
 
     # Test use_raw=True without raw (should raise error)
     adata.raw = None
+    dotmap_layout = Dotmap(
+        adata=adata,
+        marker_genes={"A": markers},
+        groupby="bulk_labels",
+        use_raw=True,
+    )
     with pytest.raises(
         ValueError, match="use_raw=True but .raw attribute is not present"
     ):
-        Dotmap(
-            adata=adata,
-            marker_genes={"A": markers},
-            groupby="bulk_labels",
-            use_raw=True,
-        )
+        dotmap_layout._plot_view()
 
 
 @pytest.mark.usefixtures("bokeh_backend")
@@ -89,17 +92,22 @@ def test_dotmap_all_missing_genes_bokeh() -> None:
     """Test error when all genes are missing with bokeh backend."""
     adata = sc.datasets.pbmc68k_reduced()
 
+    dotmap_layout = Dotmap(
+        adata=adata, marker_genes={"A": ["FAKE1", "FAKE2"]}, groupby="bulk_labels"
+    )
+
     with pytest.raises(
         ValueError, match="None of the specified marker genes are present"
     ):
-        Dotmap(
-            adata=adata, marker_genes={"A": ["FAKE1", "FAKE2"]}, groupby="bulk_labels"
-        )
+        dotmap_layout._plot_view()
 
 
 @pytest.mark.usefixtures("bokeh_backend")
 def test_dotmap_duplicate_genes_bokeh() -> None:
     adata = sc.datasets.pbmc68k_reduced()
     sel_marker_genes = {"A": ["FCN1"], "B": ["FCN1"]}
-    dotmap = Dotmap(adata=adata, marker_genes=sel_marker_genes, groupby="bulk_labels")
+    dotmap_layout = Dotmap(
+        adata=adata, marker_genes=sel_marker_genes, groupby="bulk_labels"
+    )
+    dotmap = dotmap_layout._plot_view()
     assert dotmap.data.shape == (20, 6)


### PR DESCRIPTION
Resolves #60 

- AutoTooLongName widget renamed `GeneSelector`
- `GeneSelector` updated:
  - Now handles a list of marker genes on top of a mapping of marker genes
  - Attempted to better contextualize the widget names/placeholders
  - Made the marker gene input widget a simple TextInput and no longer an autocomplete as I found that confusing
  - Enhanced behavior on init (e.g. automatically picks the first key)
- Displaying `Dotmap` now shows a mini Panel app with the `GeneSelector` widget on the left
  - Added some special handling in the widget and in `Dotmap` to allow sorting the keys from the JSON Editor (in Python `dict(a=1, b=2) == dict(b=1, a=1)` so no parameter update event is triggered by default).

```python
import panel as pn
import scanpy as sc

import hv_anndata

hv_anndata.register()
pn.extension('jsoneditor')

adata = sc.datasets.paul15()
sc.pp.pca(adata)
sc.pp.neighbors(adata)
sc.tl.umap(adata)

marker_genes = {
    "Erythroids": ["Gata1", "Klf1", "Epor", "Gypa", "Hba-a2"],
    "Neutrophils": ["Elane", "Cebpe", "Ctsg", "Mpo", "Gfi1"],
    "Monocytes": ["Irf8", "Csf1r", "Ctsg", "Mpo"],
    "Megakaryocytes": ["Itga2b", "Pbx1", "Sdpr", "Vwf"],
    "Basophils": ["Mcpt8", "Prss34"],
    "Mast cells": ["Cma1", "Gzmb"],
}

dm = hv_anndata.plotting.Dotmap(
    adata=adata,
    marker_genes=marker_genes,
    groupby="paul15_clusters",
)

dm.servable()
```
https://github.com/user-attachments/assets/f27c434d-4968-4766-a1fe-c980ba3241bf

