### PR TITLE
Remove erroneous adjoined bar from clustermap for now

### DIFF
--- a/docs/examples/scanpy/Basic.ipynb
+++ b/docs/examples/scanpy/Basic.ipynb
@@ -353,7 +353,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv_anndata.ClusterMap(adata=adata, obs_keys=\"bulk_labels\")"
+    "hv_anndata.ClusterMap(adata=adata)"
    ]
   },
   {

--- a/src/hv_anndata/plotting/clustermap.py
+++ b/src/hv_anndata/plotting/clustermap.py
@@ -96,6 +96,7 @@ def create_clustermap_plot(
         "yaxis": None,
         "show_grid": False,
         "tools": ["hover"],
+        "colorbar": True,
     }
 
     return clustered_plot.opts(

--- a/src/hv_anndata/plotting/clustermap.py
+++ b/src/hv_anndata/plotting/clustermap.py
@@ -45,7 +45,7 @@ def create_clustermap_plot(
     max_genes
         Maximum number of genes to include in the heatmap.
         If None, all genes are included.
-    **config
+    config
         Additional configuration options, see :class:`ClusterMapConfig`
 
     Returns

--- a/src/hv_anndata/plotting/clustermap.py
+++ b/src/hv_anndata/plotting/clustermap.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypedDict
 
 import anndata as ad
-import bokeh.palettes
-import colorcet as cc
 import holoviews as hv
 import numpy as np
 import pandas as pd
@@ -14,56 +12,24 @@ import panel as pn
 import panel_material_ui as pmui
 import param
 from holoviews.operation import dendrogram
-from panel.reactive import hold
 
 if TYPE_CHECKING:
     from typing import Unpack
 
-
-DEFAULT_COLOR_BY = "cell_type"
-CAT_CMAPS = {
-    "Glasbey Cat10": cc.b_glasbey_category10,
-    "Cat20": bokeh.palettes.Category20_20,
-    "Glasbey cool": cc.glasbey_cool,
-}
-CONT_CMAPS = {
-    "Viridis": bokeh.palettes.Viridis256,
-    "Fire": cc.fire,
-    "Blues": cc.blues,
-}
-DEFAULT_CAT_CMAP = cc.b_glasbey_category10
-DEFAULT_CONT_CMAP = "viridis"
-
-
-def _is_categorical(arr: np.ndarray) -> bool:
-    return (
-        arr.dtype.name in ["category", "categorical", "bool"]
-        or np.issubdtype(arr.dtype, np.object_)
-        or np.issubdtype(arr.dtype, np.str_)
-    )
+    from anndata import AnnData
 
 
 class ClusterMapConfig(TypedDict, total=False):
     """Configuration options for cluster map plotting."""
 
-    width: int
-    """width of the plot (default: 600)"""
-    height: int
-    """height of the plot (default: 400)"""
-    cmap: str | list[str]
-    """cmap for the heatmap"""
-    title: str
-    """plot title (default: "")"""
-    colorbar: bool
-    """whether to show colorbar (default: True)"""
-    show_legend: bool
-    """whether to show legend for categorical data (default: True)"""
+    cmap: str
+    """colormap for the heatmap (default: 'viridis')"""
 
 
 def create_clustermap_plot(
     adata: ad.AnnData,
-    obs_keys: str | None = None,
-    use_raw: bool | None = None,  # noqa: FBT001, RUF100
+    *,
+    use_raw: bool | None = None,
     max_genes: int | None = None,
     **config: Unpack[ClusterMapConfig],
 ) -> hv.core.layout.AdjointLayout:
@@ -73,16 +39,13 @@ def create_clustermap_plot(
     ----------
     adata
         Annotated data matrix
-    obs_keys
-        Categorical annotation to plot with different colors.
-        Currently, only a single key is supported.
     use_raw
         Whether to use `raw` attribute of `adata`.
         Defaults to `True` if `.raw` is present.
     max_genes
         Maximum number of genes to include in the heatmap.
         If None, all genes are included.
-    config
+    **config
         Additional configuration options, see :class:`ClusterMapConfig`
 
     Returns
@@ -90,21 +53,17 @@ def create_clustermap_plot(
     HoloViews AdjointLayout object containing the clustered heatmap with dendrograms
 
     """
-    # Determine whether to use raw data
     if use_raw is None:
         use_raw = adata.raw is not None
 
-    # Extract data matrix
     x = adata.raw.X if use_raw else adata.X
 
-    # Convert sparse matrix to dense if needed
     if hasattr(x, "toarray"):
         x = x.toarray()
 
     # Filter genes if max_genes is specified
     var_names = adata.var_names
     if max_genes is not None and len(var_names) > max_genes:
-        # Select genes with highest variance for better clustering
         gene_vars = np.var(x, axis=0)
         top_gene_indices = np.argsort(gene_vars)[-max_genes:]
         x = x[:, top_gene_indices]
@@ -112,91 +71,40 @@ def create_clustermap_plot(
         if var_names.name == "index":
             var_names.name = "variable"
 
-    # Prepare color data if obs_keys is provided
-    color_data = None
-    if obs_keys is not None:
-        if obs_keys not in adata.obs.columns:
-            err_msg = f"obs_keys '{obs_keys}' not found in adata.obs"
-            raise ValueError(err_msg)
-        color_data = adata.obs[obs_keys].values
+    cmap = config.get("cmap", "magma")
 
-    # Extract config with defaults
-    width = config.get("width", 600)
-    height = config.get("height", 400)
-    cmap = config.get("cmap", "viridis")
-    title = config.get("title", "")
-    colorbar = config.get("colorbar", True)
-
-    # Create DataFrame
     df = pd.DataFrame(x, index=adata.obs_names, columns=var_names)
     index_name = df.index.name or "index"
     var_name = var_names.name or "variable"
 
-    # Convert to long format for HoloViews HeatMap
+    # Convert to long format for HeatMap
     df_melted = df.reset_index().melt(
         id_vars=index_name, var_name=var_name, value_name="expression"
     )
 
-    # Add categorical annotation if provided
-    vdims = ["expression"]
-    if color_data is not None and obs_keys is not None:
-        # Create mapping from cell names to color values
-        color_mapping = dict(zip(adata.obs_names, color_data, strict=False))
-        df_melted[obs_keys] = df_melted[index_name].map(color_mapping)
-        vdims.append(obs_keys)
-
-    # Create base heatmap
-    heatmap = hv.HeatMap(df_melted, kdims=[var_name, index_name], vdims=vdims)
-
-    # Apply clustering with dendrograms
-    clustered_plot = dendrogram(
-        heatmap, main_dim="expression", adjoint_dims=[var_name, index_name]
+    main_heatmap = hv.HeatMap(
+        df_melted, kdims=[var_name, index_name], vdims=["expression"]
     )
 
-    # Configure plot options
-    plot_opts = {
-        "colorbar": colorbar,
-        "tools": ["hover"],
-        "width": width,
-        "height": height,
+    clustered_plot = dendrogram(
+        main_heatmap, main_dim="expression", adjoint_dims=[var_name, index_name]
+    )
+
+    main_plot_opts = {
         "cmap": cmap,
         "xrotation": 90,
         "yaxis": None,
         "show_grid": False,
-        "title": title,
+        "tools": ["hover"],
     }
 
     return clustered_plot.opts(
-        hv.opts.HeatMap(**plot_opts), hv.opts.Dendrogram(xaxis=None, yaxis=None)
+        hv.opts.HeatMap(**main_plot_opts), hv.opts.Dendrogram(xaxis=None, yaxis=None)
     )
 
 
 class ClusterMap(pn.viewable.Viewer):
-    """Interactive cluster map application for exploring AnnData objects.
-
-    This application provides widgets to select coloring variables and display options
-    for hierarchically-clustered heatmaps.
-
-    Parameters
-    ----------
-    adata
-        AnnData object to visualize
-    use_raw
-        Whether to use raw data from adata
-    obs_keys
-        Initial observation key to use for coloring
-    color_by_dim
-        Color by dimension, one of 'obs' (default) or 'cols'
-    cmap
-        Initial cmap to use
-    width
-        Width of the plot
-    height
-        Height of the plot
-    show_widgets
-        Whether to show control widgets
-
-    """
+    """Interactive cluster map application for exploring AnnData objects."""
 
     adata: ad.AnnData = param.ClassSelector(
         class_=ad.AnnData, doc="AnnData object to visualize"
@@ -204,154 +112,91 @@ class ClusterMap(pn.viewable.Viewer):
     use_raw: bool = param.Boolean(
         default=None, allow_None=True, doc="Whether to use raw data from adata"
     )
-    obs_keys: str = param.Selector(doc="Observation key for coloring")
-    color_by_dim: str = param.Selector(
-        default="obs",
-        objects={"Observations": "obs", "Variables": "cols"},
-        label="Color By",
+    cmap: str = param.Selector(
+        default="viridis",
+        objects=[
+            "viridis",
+            "magma",
+            "plasma",
+            "fire",
+            "blues",
+            "RdBu_r",
+            "coolwarm",
+            "seismic",
+            "bwr",
+        ],
+        doc="Colormap for expression heatmap",
+        label="Expression Colormap",
     )
-    cmap: str = param.Selector()
-    width: int = param.Integer(default=600, doc="Width of the plot")
-    height: int = param.Integer(default=400, doc="Height of the plot")
     max_genes: int = param.Integer(
         default=50,
         allow_None=True,
-        bounds=(20, 100),
+        bounds=(1, 100),
         doc="Maximum number of genes to include in the heatmap",
     )
     show_widgets: bool = param.Boolean(
         default=True, doc="Whether to show control widgets"
     )
-    _replot: bool = param.Event()
+    plot_opts: dict = param.Dict(
+        default={}, doc="HoloViews plot options for the clustermap plot"
+    )
 
-    def __init__(self, **params: object) -> None:
+    def __init__(self, adata: AnnData | None = None, **params: object) -> None:
         """Initialize the ClusterMap with the given parameters."""
-        # Widgets
+        if adata is not None:
+            params["adata"] = adata
         super().__init__(**params)
+
+        # Check if raw data exists
+        has_raw = self.adata.raw is not None
+        if self.use_raw is None:
+            self.use_raw = has_raw
+
+        use_raw_widget = pmui.widgets.Checkbox.from_param(
+            self.param.use_raw,
+            description="Use Raw Data" + ("" if has_raw else " (not available)"),
+            sizing_mode="stretch_width",
+            disabled=not has_raw,  # Disable if no raw data
+        )
+
         self._widgets = pmui.Column(
             pmui.widgets.Select.from_param(
-                self.param.obs_keys,
-                description="",
-                sizing_mode="stretch_width",
-            ),
-            pn.widgets.ColorMap.from_param(
                 self.param.cmap,
+                description="Expression Colormap",
                 sizing_mode="stretch_width",
             ),
-            pmui.widgets.Checkbox.from_param(
-                self.param.use_raw,
-                description="",
+            pmui.widgets.IntSlider.from_param(
+                self.param.max_genes,
+                description="Max Genes",
                 sizing_mode="stretch_width",
             ),
+            use_raw_widget,
             visible=self.param.show_widgets,
             sx={"border": 1, "borderColor": "#e3e3e3", "borderRadius": 1},
             sizing_mode="stretch_width",
             max_width=400,
         )
 
-        self._categorical = False
-
-        # Set up observation key options
-        obs_options = list(self.adata.obs.columns)
-        self.param["obs_keys"].objects = obs_options
-        if not self.obs_keys:
-            if DEFAULT_COLOR_BY in obs_options:
-                self.obs_keys = DEFAULT_COLOR_BY
-            else:
-                self.obs_keys = obs_options[0]
-        # Initialize colormap based on first obs_keys selection
-        if self.obs_keys:
-            color_data = self.adata.obs[self.obs_keys].values
-            self._categorical = _is_categorical(color_data)
-            cmaps = CAT_CMAPS if self._categorical else CONT_CMAPS
-            self.param.cmap.objects = cmaps
-            if not self.cmap:
-                self.cmap = next(iter(cmaps.values()))
-
-        # Set up use_raw default
-        if self.use_raw is None:
-            self.use_raw = self.adata.raw is not None
-
-    @hold()
-    @param.depends("obs_keys", watch=True)
-    def _update_on_obs_keys(self) -> None:
-        if not self.obs_keys:
-            return
-        old_is_categorical = self._categorical
-        color_data = self.adata.obs[self.obs_keys].values
-        self._categorical = _is_categorical(color_data)
-        if old_is_categorical != self._categorical or not self.cmap:
-            cmaps = CAT_CMAPS if self._categorical else CONT_CMAPS
-            self.param.cmap.objects = cmaps
-            self.cmap = next(iter(cmaps.values()))
-        self._replot = True
-
-    def create_plot(
-        self,
-        *,
-        obs_keys: str,
-        use_raw: bool,
-        cmap: list[str] | str,
-        max_genes: int | None,
-    ) -> pn.viewable.Viewable:
-        """Create a cluster map plot with the specified parameters.
-
-        Parameters
-        ----------
-        obs_keys
-            Observation key for coloring
-        use_raw
-            Whether to use raw data
-        cmap
-            cmap
-        max_genes
-            Maximum number of genes to include
-
-        Returns
-        -------
-        The clustered heatmap plot
-
-        """
+    @param.depends("use_raw", "cmap", "max_genes", "plot_opts")
+    def _plot_view(self) -> pn.viewable.Viewable:
+        """Create the plot view with parameter dependencies."""
         config = ClusterMapConfig(
-            width=self.width,
-            height=self.height,
-            cmap=cmap,
-            title=f"Clustered Heatmap - {obs_keys}",
+            cmap=self.cmap,
         )
 
-        return create_clustermap_plot(
+        plot = create_clustermap_plot(
             self.adata,
-            obs_keys=obs_keys,
-            use_raw=use_raw,
-            max_genes=max_genes,
+            use_raw=self.use_raw,
+            max_genes=self.max_genes,
             **config,
         )
 
-    @param.depends(
-        # Wrapper to fix could not be replaced with new model GridPlot(...),
-        # ensure that the parent is not modified at the same time the panel
-        # is being updated.
-        "obs_keys",
-        "use_raw",
-        "cmap",
-        "max_genes",
-        "_replot",
-    )
-    def _plot_view(self) -> pn.viewable.Viewable:
-        """Create the plot view with parameter dependencies."""
-        return self.create_plot(
-            obs_keys=self.obs_keys,
-            use_raw=self.use_raw,
-            cmap=self.cmap,
-            max_genes=self.max_genes,
-        )
+        # Apply user-provided plot options to the HeatMap only
+        if self.plot_opts:
+            plot = plot.opts(hv.opts.HeatMap(**self.plot_opts))
+
+        return plot
 
     def __panel__(self) -> pn.viewable.Viewable:
-        """Create the Panel application layout.
-
-        Returns
-        -------
-        The assembled panel application
-
-        """
+        """Create the Panel application layout."""
         return pmui.Row(self._widgets, self._plot_view)

--- a/tests/plotting/test_clustermap.py
+++ b/tests/plotting/test_clustermap.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import patch
-
 import anndata as ad
 import numpy as np
 import pandas as pd
@@ -12,10 +9,7 @@ import panel_material_ui as pmui
 import pytest
 import scanpy as sc
 
-from hv_anndata import ClusterMap, create_clustermap_plot
-
-if TYPE_CHECKING:
-    from unittest.mock import Mock
+from hv_anndata import ClusterMap
 
 
 @pytest.fixture
@@ -42,87 +36,6 @@ def sadata() -> ad.AnnData:
     adata = ad.AnnData(X=x, obs=obs, var=var)
     adata.raw = ad.AnnData(X=raw_x, var=raw_var, obs=obs)
     return adata
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-def test_create_clustermap_plot_invalid_obs_keys(sadata: ad.AnnData) -> None:
-    """Test error handling for invalid observation keys."""
-    with pytest.raises(ValueError, match="obs_keys 'invalid_key' not found"):
-        create_clustermap_plot(
-            sadata,
-            obs_keys="invalid_key",
-            use_raw=False,
-        )
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-@pytest.mark.parametrize(
-    ("kwargs", "expected"),
-    [
-        pytest.param({}, {}, id="default"),
-        pytest.param(
-            dict(obs_keys="expression_level", use_raw=False),
-            dict(obs_keys="expression_level", use_raw=False),
-            id="custom_obs_keys",
-        ),
-    ],
-)
-def test_clustermap_initialization(
-    sadata: ad.AnnData, kwargs: dict[str, object], expected: dict[str, object]
-) -> None:
-    """Test ClusterMap initialization with various parameters."""
-    cm = ClusterMap(adata=sadata, **kwargs)
-
-    assert cm.param.obs_keys.objects == expected.get(
-        "obs_keys_objects", ["cell_type", "expression_level"]
-    )
-    assert cm.obs_keys == expected.get("obs_keys", "cell_type")
-    assert cm.use_raw == expected.get(
-        "use_raw", True
-    )  # Should default to True since raw exists
-    assert cm.max_genes == expected.get("max_genes", 50)
-    assert cm.width == expected.get("width", 600)
-    assert cm.height == expected.get("height", 400)
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-def test_clustermap_update_on_obs_keys(sadata: ad.AnnData) -> None:
-    """Test that changing obs_keys updates colormap appropriately."""
-    cm = ClusterMap(adata=sadata)
-
-    # Start with categorical (cell_type)
-    initial_categorical = cm._categorical
-    initial_cmap_options = list(cm.param.cmap.objects.keys())
-
-    # Change to continuous
-    cm.obs_keys = "expression_level"
-    assert cm._categorical != initial_categorical
-    assert list(cm.param.cmap.objects.keys()) != initial_cmap_options
-
-
-@pytest.mark.usefixtures("bokeh_backend")
-@patch("hv_anndata.plotting.clustermap.create_clustermap_plot")
-def test_clustermap_create_plot(mock_ccp: Mock, sadata: ad.AnnData) -> None:
-    """Test ClusterMap create_plot method calls underlying function correctly."""
-    cm = ClusterMap(adata=sadata)
-
-    cm.create_plot(
-        obs_keys="cell_type",
-        use_raw=False,
-        cmap=["#1f77b3", "#ff7e0e"],
-        max_genes=20,
-    )
-
-    mock_ccp.assert_called_once_with(
-        sadata,
-        obs_keys="cell_type",
-        use_raw=False,
-        max_genes=20,
-        width=600,
-        height=400,
-        cmap=["#1f77b3", "#ff7e0e"],
-        title="Clustered Heatmap - cell_type",
-    )
 
 
 @pytest.mark.usefixtures("bokeh_backend")

--- a/tests/plotting/test_clustermap.py
+++ b/tests/plotting/test_clustermap.py
@@ -38,7 +38,7 @@ def sadata() -> ad.AnnData:
     return adata
 
 
-@pytest.mark.usefixtures("bokeh_backend")
+@pytest.mark.usefixtures("bokeh_renderer")
 def test_clustermap_panel_layout(sadata: ad.AnnData) -> None:
     """Test ClusterMap Panel layout creation."""
     cm = ClusterMap(adata=sadata)


### PR DESCRIPTION
...and associated cleanup.

resolves #98 

Wait for https://github.com/holoviz/holoviews/issues/6658 to use an adjoined TickBar, especially in this clustermap case where there's also a colorbar and adjoined dendrograms. 

```python
import scanpy as sc
from hv_anndata import ClusterMap
import holoviews as hv
import panel as pn

hv.extension('bokeh')
pn.extension()

adata = sc.datasets.pbmc68k_reduced()
ClusterMap(adata, plot_opts={'width':800, 'height':500})

```

<img width="1036" height="506" alt="image" src="https://github.com/user-attachments/assets/efd0ca3b-c533-49cc-8607-edf51b3322db" />


