### PR TITLE
test: Fix failing test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           enable-cache: true
       - run: uv tool install '--with=click!=8.3.0' hatch
       - run: hatch test --cover --python=${{ matrix.python-version }}
-      - run: hatch --env hatch-test.py${{ matrix.python-version }} run coverage xml
+      - run: hatch env run --env hatch-test.py${{ matrix.python-version }} -- coverage xml
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml


### PR DESCRIPTION
Seeing this error both in [CI](https://github.com/holoviz-topics/hv-anndata/actions/runs/17856045329/job/50911332922) and locally, not sure what has caused it. 

``` 
❯ uvx hatch --env hatch-test.py3.11 run coverage xml
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/hatch/cli/__in │
│ it__.py:221 in main                                                                              │
│                                                                                                  │
│   218                                                                                            │
│   219 def main():  # no cov                                                                      │
│   220 │   try:                                                                                   │
│ ❱ 221 │   │   hatch(prog_name='hatch', windows_expand_args=False)                                │
│   222 │   except Exception:  # noqa: BLE001                                                      │
│   223 │   │   import sys                                                                         │
│   224                                                                                            │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 1462 in __call__                                                                                 │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 1383 in main                                                                                     │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 1850 in invoke                                                                                   │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 1246 in invoke                                                                                   │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 814 in invoke                                                                                    │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/decorato │
│ rs.py:34 in new_func                                                                             │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/hatch/cli/run/ │
│ __init__.py:147 in run                                                                           │
│                                                                                                  │
│   144 │   elif not env_name:                                                                     │
│   145 │   │   env_name = 'system'                                                                │
│   146 │                                                                                          │
│ ❱ 147 │   ctx.invoke(                                                                            │
│   148 │   │   run_command,                                                                       │
│   149 │   │   args=[command, *final_args],                                                       │
│   150 │   │   env_names=[env_name],                                                              │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/core.py: │
│ 814 in invoke                                                                                    │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/click/decorato │
│ rs.py:46 in new_func                                                                             │
│                                                                                                  │
│ /home/shh/.cache/uv/archive-v0/m3bMEpyalPdKojrlBDGmZ/lib/python3.12/site-packages/hatch/cli/env/ │
│ run.py:123 in run                                                                                │
│                                                                                                  │
│   120 │   if filter_json:                                                                        │
│   121 │   │   import json                                                                        │
│   122 │   │                                                                                      │
│ ❱ 123 │   │   filter_data = json.loads(filter_json)                                              │
│   124 │   │   if not isinstance(filter_data, dict):                                              │
│   125 │   │   │   app.abort('The --filter/-f option must be a JSON mapping')                     │
│   126                                                                                            │
│                                                                                                  │
│ /home/shh/.local/share/uv/python/cpython-3.12.9-linux-x86_64-gnu/lib/python3.12/json/__init__.py │
│ :339 in loads                                                                                    │
│                                                                                                  │
│   336 │   │   │   │   │   │   │   │     s, 0)                                                    │
│   337 │   else:                                                                                  │
│   338 │   │   if not isinstance(s, (bytes, bytearray)):                                          │
│ ❱ 339 │   │   │   raise TypeError(f'the JSON object must be str, bytes or bytearray, '           │
│   340 │   │   │   │   │   │   │   f'not {s.__class__.__name__}')                                 │
│   341 │   │   s = s.decode(detect_encoding(s), 'surrogatepass')                                  │
│   342                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: the JSON object must be str, bytes or bytearray, not Sentinel

```