### PR TITLE
don’t allow FutureWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ addopts = [ "--import-mode=importlib", "--strict-markers" ]
 filterwarnings = [
   "error",
   # add ignore filters here if something fails in 3rd party dependencies
-  "default:Probably comparing to a dimension created from `Dimension.name`:FutureWarning",
 ]
 
 [tool.coverage]


### PR DESCRIPTION
This exposes the places where holoviz/holoviews#6799 is problematic.

This part would need to be changed if once holoviews gets fixes: https://github.com/holoviz-topics/hv-anndata/blob/c80a6779c31a79aa21fc8ada3ceec315f4aa5166/src/hv_anndata/plotting/manifoldmap.py#L194-L199