### PR TITLE
Allow customizing legend

### DIFF
--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -264,7 +264,7 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
     return plot.opts(
         title=title,
         show_legend=show_legend,
-        legend_ncols=legend_ncols,
+        legend_cols=legend_ncols,
         legend_opts={
             "background_fill_alpha": legend_alpha,
             "border_line_alpha": legend_alpha,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -80,6 +80,12 @@ class ManifoldMapConfig(TypedDict, total=False):
     labeller_opts: dict[str, Any]
     legend_position: str
     """Bokeh legend position (default: "bottom_right")"""
+    legend_alpha: float
+    """Legend background opacity (default: 0.6)"""
+    legend_font_size: str
+    """Legend label font size (default: "8pt")"""
+    legend_ncols: int
+    """Number of legend columns (default: 1)"""
 
 
 def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
@@ -134,6 +140,9 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
     ls = config.get("ls")
     labeller_opts = config.get("labeller_opts")
     legend_position = config.get("legend_position", "bottom_right")
+    legend_alpha = config.get("legend_alpha", 0.6)
+    legend_font_size = config.get("legend_font_size", 8)
+    legend_ncols = config.get("legend_ncols", 1)
 
     color_data = adata[color_by]
 
@@ -186,7 +195,6 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
         ],
         show_legend=show_legend,
         legend_position=legend_position,
-        legend_opts={"background_fill_alpha": 0.6},
     )
 
     # Apply different rendering based on configuration
@@ -253,7 +261,17 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
         final_kwargs["ylabel"] = yaxis_label
 
     # Apply final options to the plot
-    return plot.opts(title=title, show_legend=show_legend, **final_kwargs)
+    return plot.opts(
+        title=title,
+        show_legend=show_legend,
+        legend_cols=legend_ncols,
+        legend_opts={
+            "background_fill_alpha": legend_alpha,
+            "border_line_alpha": legend_alpha,
+            "label_text_font_size": f"{legend_font_size}pt",
+        },
+        **final_kwargs,
+    )
 
 
 def _apply_categorical_datashading(
@@ -304,7 +322,6 @@ def _apply_categorical_datashading(
         selector_in_hovertool=False,
         show_legend=True,
         legend_position=legend_position,
-        legend_opts={"background_fill_alpha": 0.6},
     )
 
 
@@ -408,8 +425,38 @@ class ManifoldMap(pn.viewable.Viewer):
     plot_opts: dict = param.Dict(  # type: ignore[assignment]
         default={}, doc="HoloViews plot options for the manifoldmap plot"
     )
-    legend_position: str = param.String(  # type: ignore[assignment]
-        default="bottom_right", doc="Bokeh legend position"
+    legend_position: str = param.Selector(  # type: ignore[assignment]
+        default="bottom_right",
+        objects=[
+            "top_left",
+            "top_center",
+            "top_right",
+            "center_left",
+            "center",
+            "center_right",
+            "bottom_left",
+            "bottom_center",
+            "bottom_right",
+            "right",
+            "left",
+        ],
+        doc="Bokeh legend position",
+    )
+    legend_alpha: float = param.Number(  # type: ignore[assignment]
+        default=0.6,
+        bounds=(0, 1),
+        step=0.1,
+        doc="Legend background opacity",
+    )
+    legend_font_size: int = param.Integer(  # type: ignore[assignment]
+        default=8,
+        bounds=(5, 14),
+        doc="Legend label font size in pt",
+    )
+    legend_ncols: int = param.Integer(  # type: ignore[assignment]
+        default=1,
+        bounds=(1, 4),
+        doc="Number of legend columns",
     )
     labeller_opts: dict = param.Dict(  # type: ignore[assignment]
         default={}, doc="Operation and plot options for the labeller"
@@ -604,6 +651,9 @@ class ManifoldMap(pn.viewable.Viewer):
             ls=self.ls,
             labeller_opts=self.labeller_opts,
             legend_position=self.legend_position,
+            legend_alpha=self.legend_alpha,
+            legend_font_size=self.legend_font_size,
+            legend_ncols=self.legend_ncols,
         )
 
         self.plot = create_manifoldmap_plot(
@@ -633,6 +683,10 @@ class ManifoldMap(pn.viewable.Viewer):
         "_replot",
         "plot_opts",
         "color_by",
+        "legend_position",
+        "legend_alpha",
+        "legend_font_size",
+        "legend_ncols",
     )
     def _plot_view(self) -> hv.Element:
         plot = self.create_plot(
@@ -711,6 +765,32 @@ class ManifoldMap(pn.viewable.Viewer):
             pmui.widgets.Checkbox.from_param(
                 self.param.show_labels,
                 description="Overlay labels for categorical coloring",
+                sizing_mode="stretch_width",
+                visible=self.param._categorical,  # noqa: SLF001
+            ),
+            pmui.Details(
+                pmui.widgets.Select.from_param(
+                    self.param.legend_position,
+                    sizing_mode="stretch_width",
+                ),
+                pn.widgets.FloatSlider.from_param(
+                    self.param.legend_alpha,
+                    name="Legend Opacity",
+                    sizing_mode="stretch_width",
+                    value_throttled=self.param.legend_alpha,
+                ),
+                pmui.widgets.IntSlider.from_param(
+                    self.param.legend_font_size,
+                    name="Font Size (pt)",
+                    sizing_mode="stretch_width",
+                    value_throttled=self.param.legend_font_size,
+                ),
+                pmui.widgets.IntSlider.from_param(
+                    self.param.legend_ncols,
+                    sizing_mode="stretch_width",
+                    value_throttled=self.param.legend_ncols,
+                ),
+                title="Legend Options",
                 sizing_mode="stretch_width",
                 visible=self.param._categorical,  # noqa: SLF001
             ),

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -264,7 +264,7 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
     return plot.opts(
         title=title,
         show_legend=show_legend,
-        legend_cols=legend_ncols,
+        legend_ncols=legend_ncols,
         legend_opts={
             "background_fill_alpha": legend_alpha,
             "border_line_alpha": legend_alpha,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -78,6 +78,8 @@ class ManifoldMapConfig(TypedDict, total=False):
     ls: link_selections | None
     """Operation and plot options for the labeller"""
     labeller_opts: dict[str, Any]
+    legend_position: str
+    """Bokeh legend position (default: "bottom_right")"""
 
 
 def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
@@ -131,6 +133,7 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
     streams = config.get("streams", [])
     ls = config.get("ls")
     labeller_opts = config.get("labeller_opts")
+    legend_position = config.get("legend_position", "bottom_right")
 
     color_data = adata[color_by]
 
@@ -182,7 +185,7 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
             LassoSelectTool(persistent=True),
         ],
         show_legend=show_legend,
-        legend_position="bottom_right",
+        legend_position=legend_position,
         legend_opts={"background_fill_alpha": 0.6},
     )
 
@@ -194,7 +197,12 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # Apply datashading with different approaches for categorical vs continuous
     # TODO: change once https://github.com/holoviz/holoviews/issues/6799 is fixed
     elif categorical:
-        plot = _apply_categorical_datashading(plot, color_by=color_by.name, cmap=cmap)
+        plot = _apply_categorical_datashading(
+            plot,
+            color_by=color_by.name,
+            cmap=cmap,
+            legend_position=legend_position,
+        )
     else:
         # For continuous data, take the mean
         aggregator = ds.mean(color_by.name)
@@ -249,7 +257,11 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
 
 
 def _apply_categorical_datashading(
-    plot: hv.Element, *, color_by: str, cmap: Sequence[str]
+    plot: hv.Element,
+    *,
+    color_by: str,
+    cmap: Sequence[str],
+    legend_position: str = "bottom_right",
 ) -> hv.Element:
     """Apply datashading to categorical data.
 
@@ -261,6 +273,8 @@ def _apply_categorical_datashading(
         Name of the color variable
     cmap
         Colormap to use
+    legend_position
+        Position for the legend
 
     Returns
     -------
@@ -289,7 +303,7 @@ def _apply_categorical_datashading(
         # Don't include the selector heading
         selector_in_hovertool=False,
         show_legend=True,
-        legend_position="bottom_right",
+        legend_position=legend_position,
         legend_opts={"background_fill_alpha": 0.6},
     )
 
@@ -393,6 +407,9 @@ class ManifoldMap(pn.viewable.Viewer):
     )
     plot_opts: dict = param.Dict(  # type: ignore[assignment]
         default={}, doc="HoloViews plot options for the manifoldmap plot"
+    )
+    legend_position: str = param.String(  # type: ignore[assignment]
+        default="bottom_right", doc="Bokeh legend position"
     )
     labeller_opts: dict = param.Dict(  # type: ignore[assignment]
         default={}, doc="Operation and plot options for the labeller"
@@ -586,6 +603,7 @@ class ManifoldMap(pn.viewable.Viewer):
             streams=self.streams,
             ls=self.ls,
             labeller_opts=self.labeller_opts,
+            legend_position=self.legend_position,
         )
 
         self.plot = create_manifoldmap_plot(

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -182,7 +182,8 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
             LassoSelectTool(persistent=True),
         ],
         show_legend=show_legend,
-        legend_position="right",
+        legend_position="bottom_right",
+        legend_opts={"background_fill_alpha": 0.6},
     )
 
     # Apply different rendering based on configuration
@@ -288,7 +289,8 @@ def _apply_categorical_datashading(
         # Don't include the selector heading
         selector_in_hovertool=False,
         show_legend=True,
-        legend_position="right",
+        legend_position="bottom_right",
+        legend_opts={"background_fill_alpha": 0.6},
     )
 
 

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -261,17 +261,15 @@ def create_manifoldmap_plot(  # noqa: C901, PLR0912, PLR0914, PLR0915
         final_kwargs["ylabel"] = yaxis_label
 
     # Apply final options to the plot
-    return plot.opts(
-        title=title,
-        show_legend=show_legend,
-        legend_cols=legend_ncols,
-        legend_opts={
+    final_opts = dict(title=title, show_legend=show_legend, **final_kwargs)
+    if show_legend:
+        final_opts["legend_cols"] = legend_ncols
+        final_opts["legend_opts"] = {
             "background_fill_alpha": legend_alpha,
             "border_line_alpha": legend_alpha,
             "label_text_font_size": f"{legend_font_size}pt",
-        },
-        **final_kwargs,
-    )
+        }
+    return plot.opts(**final_opts)
 
 
 def _apply_categorical_datashading(

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -73,7 +73,7 @@ def test_create_manifoldmap_plot_no_datashading(
     assert plot_opts["padding"] == 0
     assert len(plot_opts["tools"]) == 3
     assert "hover" in plot_opts["tools"]
-    assert plot_opts["legend_position"] == "right"
+    assert plot_opts["legend_position"] == "bottom_right"
     assert plot_opts["min_width"] == 300
     assert plot_opts["min_height"] == 300
     assert plot_opts["responsive"]
@@ -186,6 +186,10 @@ def test_manifoldmap_create_plot(mock_cmp: Mock, sadata: ad.AnnData) -> None:
         responsive=True,
         ls=None,
         labeller_opts={},
+        legend_position="bottom_right",
+        legend_alpha=0.6,
+        legend_font_size=8,
+        legend_ncols=1,
     )
 
 

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -189,7 +189,7 @@ def test_manifoldmap_create_plot(mock_cmp: Mock, sadata: ad.AnnData) -> None:
         legend_position="bottom_right",
         legend_alpha=0.6,
         legend_font_size=8,
-        legend_cols=1,
+        legend_ncols=1,
     )
 
 

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -189,7 +189,7 @@ def test_manifoldmap_create_plot(mock_cmp: Mock, sadata: ad.AnnData) -> None:
         legend_position="bottom_right",
         legend_alpha=0.6,
         legend_font_size=8,
-        legend_ncols=1,
+        legend_cols=1,
     )
 
 


### PR DESCRIPTION
Adds a details section for adjusting legend.

Before:
<img width="692" height="650" alt="image" src="https://github.com/user-attachments/assets/93a751b1-d9c1-46a9-b35d-da7baf28fb12" />

After:
<img width="981" height="685" alt="image" src="https://github.com/user-attachments/assets/4a5b715f-999d-4a83-b50d-e93e743f9955" />
<img width="290" height="316" alt="image" src="https://github.com/user-attachments/assets/90269c94-43d1-435d-803f-df8a398f0fe4" />
