### PR TITLE
test: Enable error on filterwarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ envs.hatch-test.dependencies = [
   "pytest-cov",
   "nbformat-types",
   "scanpy",
-  "holoviews>=1.23.0rc0",  # Can be removed from final release
+  "holoviews>=1.23.0rc0", # Can be removed from final release
 ]
 metadata.hooks.docstring-description = {}
 version.source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ envs.hatch-test.dependencies = [
   "pytest-cov",
   "nbformat-types",
   "scanpy",
+  "holoviews>=1.23.0rc0",  # Can be removed from final release
 ]
 metadata.hooks.docstring-description = {}
 version.source = "vcs"
@@ -129,7 +130,6 @@ addopts = [ "--import-mode=importlib", "--strict-markers" ]
 filterwarnings = [
   "error",
   # add ignore filters here if something fails in 3rd party dependencies
-  "default:Probably comparing to a dimension created from `Dimension.name`:FutureWarning",
 ]
 
 [tool.coverage]

--- a/src/hv_anndata/interface.py
+++ b/src/hv_anndata/interface.py
@@ -376,7 +376,7 @@ class AnnDataInterface(hv.core.Interface):
         for k in dimensions:
             dim = cls._dim(dataset, k)
             cls.validate_selection_dim(dim, "group")
-            values[k] = unique_iterator(adata[dim])
+            values[dim] = unique_iterator(adata[dim])
 
         # Get dimensions information
         dimensions = [dataset.get_dimension(d) for d in dimensions]

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -107,11 +107,11 @@ def test_create_manifoldmap_plot_datashading(
     dop = el.pipeline.find(dynspread, skip_nonlinked=False)
     if color_kind == "categorical":
         assert rop.name.startswith("datashade")
-        assert rop.aggregator.cat_column == by
+        assert rop.aggregator.cat_column == by.name
     elif color_kind == "continuous":
         assert rop.name.startswith("rasterize")
         assert type(rop.aggregator).__name__ == "mean"
-        assert rop.aggregator.column == by
+        assert rop.aggregator.column == by.name
     assert dop.name.startswith("dynspread")
     assert dop.threshold == pytest.approx(0.5)
 


### PR DESCRIPTION
With https://github.com/holoviz/holoviews/pull/6853 we can error on all warnings