### PR TITLE
docs: simplify `sphinx-exec-jupyter` usage

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,5 +11,5 @@ build:
     - asdf global uv latest
     build:
       html:
-      - env UV_CONSTRAINT=.github/constraints.txt uvx hatch run docs:build
+      - env UV_CONSTRAINT=.github/constraints.txt uvx hatch run docs:build -T
       - mv docs/_build $READTHEDOCS_OUTPUT

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from functools import partial
 from importlib.metadata import metadata
 from pathlib import Path
 from subprocess import run
@@ -64,31 +63,12 @@ nb_execution_show_tb = True
 nb_execution_timeout = 30  # seconds
 
 holoviews_backends = ["bokeh", "matplotlib", "plotly"]
+exec_jupyter_code = "import hv_anndata"
+exec_jupyter_kernel = "hv-anndata"
+
+run(["hatch", "-v", "run", "docs:install-kernel"], check=True)
 
 # autodoc/autosummary
 autodoc_default_options = {
     "members": False,
 }
-
-
-# https://github.com/executablebooks/MyST-NB/issues/574
-def _patch_myst_nb() -> None:
-    from jupyter_cache.executors import (  # type: ignore[import-not-found]  # noqa: PLC0415
-        utils,
-    )
-    from myst_nb.core.execute import (  # type: ignore[import-not-found]  # noqa: PLC0415
-        cache,
-        direct,
-    )
-
-    run(
-        ["hatch", "-v", "run", "docs:install-kernel"],
-        check=True,
-    )
-
-    cache.single_nb_execution = direct.single_nb_execution = partial(
-        utils.single_nb_execution, kernel_name="hv-anndata"
-    )
-
-
-_patch_myst_nb()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ napoleon_use_param = True
 # myst_nb settings
 nb_execution_mode = "cache"
 nb_execution_show_tb = True
-nb_execution_timeout = 30  # seconds
+nb_execution_timeout = 60  # seconds
 
 holoviews_backends = ["bokeh", "matplotlib", "plotly"]
 exec_jupyter_code = "import hv_anndata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = [
   "sphinx",
   "sphinx-autodoc-typehints",
   "sphinx-design",
-  "sphinx-exec-jupyter[holoviews] @ git+https://github.com/flying-sheep/sphinx-exec-jupyter.git@fork",
+  "sphinx-exec-jupyter[holoviews] @ git+https://github.com/flying-sheep/sphinx-exec-jupyter.git",
   "sphinx-issues",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = [
   "sphinx",
   "sphinx-autodoc-typehints",
   "sphinx-design",
-  "sphinx-exec-jupyter[holoviews] @ git+https://github.com/flying-sheep/sphinx-exec-jupyter.git",
+  "sphinx-exec-jupyter[holoviews]",
   "sphinx-issues",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docs = [
   "sphinx",
   "sphinx-autodoc-typehints",
   "sphinx-design",
-  "sphinx-exec-jupyter[holoviews] @ git+https://github.com/flying-sheep/sphinx-exec-jupyter.git",
+  "sphinx-exec-jupyter[holoviews] @ git+https://github.com/flying-sheep/sphinx-exec-jupyter.git@fork",
   "sphinx-issues",
 ]
 

--- a/src/hv_anndata/interface.py
+++ b/src/hv_anndata/interface.py
@@ -337,7 +337,7 @@ class AnnDataInterface(hv.core.Interface):
         cls,
         dataset: Dataset,
         kdims: list[Dimension | str],
-        function: Callable[ValueType, ValueType],
+        function: Callable[[ValueType], ValueType],
         **kwargs: Any,  # noqa: ANN401
     ) -> tuple[pd.DataFrame, list[Dimension]]:
         """Aggregate the current view."""

--- a/src/hv_anndata/plotting/scanpy/_core.py
+++ b/src/hv_anndata/plotting/scanpy/_core.py
@@ -506,7 +506,6 @@ def matrixplot(
         )
 
     """
-    # TODO: make AdDim inspectable: https://github.com/holoviz-topics/hv-anndata/pull/87
     if not isinstance(group_by.acc, MetaAcc):
         msg = f"`by` needs to be `A.obs['…']` or `A.var['…']`, got {group_by!r}"
         raise TypeError(msg)


### PR DESCRIPTION
Testing this PR: https://github.com/flying-sheep/sphinx-exec-jupyter/pull/12

If all goes well, this should build the docs much faster.

- Before this PR, the docs build takes 9:40 minutes.
- after, it takes 6:20 minutes (time saved importing holoviews)

TODO: setting `import hv_anndata` seems to have made no difference somehow, why?