### PR TITLE
ci: update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
     - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
     - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
   # Dry-run only
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * SUN'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,24 +12,37 @@ on:
     - cron: '0 15 * * SUN'
 
 env:
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.14"
 
 jobs:
-  pip_build:
-    name: Build PyPI
+  build:
+    name: Build package
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write # to authenticate as Trusted Publisher to pypi.org
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: pip install build
       - run: python -m build
-      - name: Publish to PyPI
-        if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish on PyPI
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,4 +47,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,8 @@ on:
   schedule:
     - cron: '0 15 * * SUN'
 
+permissions: {}
+
 env:
   PYTHON_VERSION: "3.14"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,19 +28,19 @@ jobs:
         - { python: "3.14", feats: min }
         - { python: "3.14", feats: full }
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: ${{ matrix.python }}
       - run: uv tool install hatch
       - run: hatch -v env create hatch-test.py${{ matrix.python }}-${{ matrix.feats }}
       - run: hatch test --cover --python=${{ matrix.python }} -i feature-set=${{ matrix.feats }}
       - run: hatch env run --env hatch-test.py${{ matrix.python }}-${{ matrix.feats }} -- coverage xml
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           use_oidc: true
@@ -50,6 +50,6 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,7 @@ repos:
   rev: "0.9.1"
   hooks:
     - id: nbstripout
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.26.1
+  hooks:
+    - id: zizmor


### PR DESCRIPTION
Split the workflow into two so only real deployments show up in the sidebar.

Also pin actions and activate zizmor for security (follow-up to #149)