### PR TITLE
Make manifold map more robust

### DIFF
--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -546,8 +546,11 @@ class ManifoldMap(pn.viewable.Viewer):
     def _get_dim(self) -> AdDim:
         if self.color_by_dim == "obs":
             return A.obs[self.color_by]
+        # Color each observation by the gene's expression (a column of X, i.e. an
+        # obs-axis vector) so it matches the obsm-based x/y coordinates.
+        # Referencing the var axis here raises a DataError (obs vs var mismatch).
         if not self.var_reference:
-            return A.var.index
+            return A.X[:, self.color_by]
         var = self.adata.var.query(f'feature_name == "{self.color_by}"').index
         if len(var) > 1:
             msg = (
@@ -555,7 +558,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 f"for {self.color_by!r}."
             )
             raise RuntimeError(msg)
-        return A.var[self.color_by]
+        return A.X[:, var[0]]
 
     @staticmethod
     def get_reduction_label(dr_key: str) -> str:
@@ -628,9 +631,7 @@ class ManifoldMap(pn.viewable.Viewer):
         dr_label = self.get_reduction_label(dr_key)
 
         if not color_by:
-            return pmui.pane.Typography(
-                "Please select a variable to color by."
-            )
+            return pmui.pane.Typography("Please select a variable to color by.")
 
         if x_value == y_value:
             return pmui.pane.Typography(
@@ -753,24 +754,24 @@ class ManifoldMap(pn.viewable.Viewer):
             stylesheets=[stylesheet],
             sizing_mode="stretch_width",
         )
-        # Create widget box. Use a Bokeh-managed pn.Column (not pmui.Column) so
-        # the Bokeh ColorMap widget isn't a child of a React subtree -- React's
-        # reconciler was tearing out the ColorMap's DOM on mount. pmui widgets
-        # render fine as children of a pn.Column (React islands in a Bokeh layout).
+        # Create widget box in a Bokeh pn.Column so the Bokeh ColorMap isn't a
+        # child of a React subtree (React tears out its DOM on mount). The
+        # selectors use AutocompleteInput rather than Select: pmui's Select
+        # renders its dropdown in an MUI portal that mis-anchors to the top-left
+        # inside a Bokeh layout, whereas AutocompleteInput anchors correctly.
+        select_kw = dict(
+            min_characters=0,
+            search_strategy="includes",
+            case_sensitive=False,
+            description="",
+            sizing_mode="stretch_width",
+        )
         widgets = pn.Column(
-            pmui.widgets.Select.from_param(
-                self.param.reduction,
-                description="",
-                sizing_mode="stretch_width",
+            pmui.widgets.AutocompleteInput.from_param(
+                self.param.reduction, **select_kw
             ),
-            pmui.widgets.Select.from_param(
-                self.param.x_axis,
-                sizing_mode="stretch_width",
-            ),
-            pmui.widgets.Select.from_param(
-                self.param.y_axis,
-                sizing_mode="stretch_width",
-            ),
+            pmui.widgets.AutocompleteInput.from_param(self.param.x_axis, **select_kw),
+            pmui.widgets.AutocompleteInput.from_param(self.param.y_axis, **select_kw),
             color_by_dim,
             color,
             colormap,
@@ -786,9 +787,8 @@ class ManifoldMap(pn.viewable.Viewer):
                 visible=self.param._categorical,  # noqa: SLF001
             ),
             pmui.Details(
-                pmui.widgets.Select.from_param(
-                    self.param.legend_position,
-                    sizing_mode="stretch_width",
+                pmui.widgets.AutocompleteInput.from_param(
+                    self.param.legend_position, **select_kw
                 ),
                 pn.widgets.FloatSlider.from_param(
                     self.param.legend_alpha,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -518,10 +518,16 @@ class ManifoldMap(pn.viewable.Viewer):
         if old_is_categorical != self._categorical or not self.colormap:
             cmaps = CAT_CMAPS if self._categorical else CONT_CMAPS
             self.param.colormap.objects = cmaps
-            if self.colormap is None or self.colormap not in cmaps:
-                self.colormap = next(iter(cmaps.values()))
-            else:
-                self.colormap = cmaps[self.colormap]
+            # colormap holds a palette (list) once selected, or a name (str)
+            # initially; membership must test values, not (unhashable) keys.
+            current = (
+                cmaps.get(self.colormap)
+                if isinstance(self.colormap, str)
+                else self.colormap
+            )
+            if current not in cmaps.values():
+                current = next(iter(cmaps.values()))
+            self.colormap = current
         self._replot = True
 
     @hold()
@@ -621,6 +627,11 @@ class ManifoldMap(pn.viewable.Viewer):
         """
         dr_label = self.get_reduction_label(dr_key)
 
+        if not color_by:
+            return pmui.pane.Typography(
+                "Please select a variable to color by."
+            )
+
         if x_value == y_value:
             return pmui.pane.Typography(
                 "Please select different dimensions for X and Y axes."
@@ -696,6 +707,11 @@ class ManifoldMap(pn.viewable.Viewer):
             show_labels=self.show_labels,
             cmap=self.colormap,
         )
+        # create_plot returns a Typography pane (not a HoloViews element) for
+        # invalid axis selections, e.g. the transient x == y state while
+        # switching reductions; only apply opts to real hv elements.
+        if not isinstance(plot, hv.core.Dimensioned):
+            return plot
         return plot.opts(**self.plot_opts)
 
     def __panel__(self) -> pn.viewable.Viewable:
@@ -737,8 +753,11 @@ class ManifoldMap(pn.viewable.Viewer):
             stylesheets=[stylesheet],
             sizing_mode="stretch_width",
         )
-        # Create widget box
-        widgets = pmui.Column(
+        # Create widget box. Use a Bokeh-managed pn.Column (not pmui.Column) so
+        # the Bokeh ColorMap widget isn't a child of a React subtree -- React's
+        # reconciler was tearing out the ColorMap's DOM on mount. pmui widgets
+        # render fine as children of a pn.Column (React islands in a Bokeh layout).
+        widgets = pn.Column(
             pmui.widgets.Select.from_param(
                 self.param.reduction,
                 description="",
@@ -793,7 +812,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 visible=self.param._categorical,  # noqa: SLF001
             ),
             visible=self.param.show_widgets,
-            sx={"border": 1, "borderColor": "#e3e3e3", "borderRadius": 1},
+            styles={"border": "1px solid #e3e3e3", "border-radius": "4px"},
             sizing_mode="stretch_width",
             max_width=280,
             min_height=590,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -558,7 +558,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 f"for {self.color_by!r}."
             )
             raise RuntimeError(msg)
-        return A.X[:, var[0]]
+        return A.var[self.color_by]
 
     @staticmethod
     def get_reduction_label(dr_key: str) -> str:

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -10,11 +10,13 @@ import holoviews as hv
 import numpy as np
 import pandas as pd
 import panel as pn
+import panel_material_ui as pmui
 import pytest
 from holoviews.operation.datashader import dynspread, rasterize
 
 from hv_anndata import A, ManifoldMap, create_manifoldmap_plot
 from hv_anndata.interface import register, unregister
+from hv_anndata.plotting.manifoldmap import CAT_CMAPS, CONT_CMAPS
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -211,3 +213,92 @@ def test_manifoldmap_streams(sadata: ad.AnnData) -> None:
     assert bounds_xy.source is None
     mm.__panel__()
     assert bounds_xy.source is not None
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_get_dim_cols_uses_x_column(sadata: ad.AnnData) -> None:
+    """color_by_dim="cols" without var_reference must read expression from X.
+
+    A.var.index has no per-observation values and mismatches the obsm-based
+    x/y coordinates on the obs axis; see #161.
+    """
+    mm = ManifoldMap(adata=sadata, color_by_dim="cols", color_by="gene_1")
+
+    assert mm._get_dim() == A.X[:, "gene_1"]
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_color_by_cols_plot_view_no_var_reference(
+    sadata: ad.AnnData,
+) -> None:
+    """Coloring by a variable (no var_reference) renders instead of raising.
+
+    Previously raised a HoloViews DataError mixing the obs and var axes; see
+    #161.
+    """
+    mm = ManifoldMap(adata=sadata, color_by_dim="cols", color_by="gene_1")
+
+    plot = mm._plot_view()
+
+    assert isinstance(plot, hv.core.Dimensioned)
+    assert mm._categorical is False
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_colormap_survives_categorical_round_trip(
+    sadata: ad.AnnData,
+) -> None:
+    """colormap must round-trip through a categorical/continuous/categorical cycle.
+
+    Once selected, colormap holds an unhashable palette list rather than its
+    name, so membership must be tested against dict values, not keys, or this
+    raises `TypeError: unhashable type: 'list'`; see #161.
+    """
+    mm = ManifoldMap(adata=sadata, color_by="cell_type")
+    assert mm.colormap in CAT_CMAPS.values()
+
+    mm.color_by = "expression_level"
+    assert mm._categorical is False
+    assert mm.colormap in CONT_CMAPS.values()
+
+    mm.color_by = "cell_type"
+    assert mm._categorical is True
+    assert mm.colormap in CAT_CMAPS.values()
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+@pytest.mark.parametrize("color_by", [None, ""], ids=["none", "empty_string"])
+def test_manifoldmap_create_plot_no_color_by(
+    sadata: ad.AnnData, color_by: str | None
+) -> None:
+    """create_plot shows a prompt instead of erroring when color_by is unset."""
+    mm = ManifoldMap(adata=sadata)
+
+    result = mm.create_plot(
+        dr_key="X_umap",
+        x_value="UMAP1",
+        y_value="UMAP2",
+        color_by=color_by,
+        datashade_value=False,
+        show_labels=False,
+        cmap=None,
+    )
+
+    assert isinstance(result, pmui.pane.Typography)
+    assert "select a variable to color by" in result.object
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_plot_view_skips_opts_for_error_pane(sadata: ad.AnnData) -> None:
+    """_plot_view must not call .opts() on a Typography error pane from create_plot.
+
+    Typography has no `.opts()`, so calling it unconditionally would raise;
+    see #161.
+    """
+    mm = ManifoldMap(adata=sadata)
+    error_pane = pmui.pane.Typography("boom")
+    mm.create_plot = lambda **_: error_pane
+
+    plot = mm._plot_view()
+
+    assert plot is error_pane


### PR DESCRIPTION
1. Colormap wasn't changing due to pmui.Column incompatible with pn.widgets.Colormap; changing to pn.Column works
2. However, this resulted in pmui.Select not properly anchored--changing to pmui.AutoCompleteInput works and is consistent with color by.
3. Changing things might result in `Typography.opts()` which crashes, so add a return early if not hv
4. Selecting var crashes with: `holoviews.core.data.interface.DataError: AnnData Dataset in tabular mode must reference data along either the obs or the var axis, not both.` so use `A.X[:, self.color_by]`

Old:

https://github.com/user-attachments/assets/e7147ced-65b0-4a6f-aaac-36f5a94075c8

New:

https://github.com/user-attachments/assets/12befdf0-dcbd-400a-b284-0aef432fe410

