### PR TITLE
Add current_kdims for downstream

### DIFF
--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -593,6 +593,31 @@ class ManifoldMap(pn.viewable.Viewer):
         num_dims = self.adata.obsm[dr_key].shape[1]
         return [f"{dr_label}{i + 1}" for i in range(num_dims)]
 
+    @staticmethod
+    def _dim_index(dr_label: str, value: str) -> int:
+        """Parse the 0-based column index from an axis label (``"UMAP2"`` -> 1)."""
+        return int(value.replace(dr_label, "")) - 1
+
+    def current_kdims(self) -> list[AdDim]:
+        """Key dimensions for the active reduction and axes.
+
+        Downstream code should build its :class:`holoviews.Dataset` from these
+        so a selection expression emitted by the plot resolves against it,
+        rather than assuming a fixed reduction or axis order.
+
+        Returns
+        -------
+        List of key dimensions for the current reduction and axes
+
+        """
+        dr_label = self.get_reduction_label(self.reduction)
+        x_dim = self._dim_index(dr_label, self.x_axis)
+        y_dim = self._dim_index(dr_label, self.y_axis)
+        return [
+            A.obsm[self.reduction][:, x_dim],
+            A.obsm[self.reduction][:, y_dim],
+        ]
+
     def create_plot(
         self,
         *,
@@ -640,8 +665,8 @@ class ManifoldMap(pn.viewable.Viewer):
 
         # Extract indices from dimension labels
         try:
-            x_dim = int(x_value.replace(dr_label, "")) - 1
-            y_dim = int(y_value.replace(dr_label, "")) - 1
+            x_dim = self._dim_index(dr_label, x_value)
+            y_dim = self._dim_index(dr_label, y_value)
         except (ValueError, AttributeError):
             return pmui.pane.Typography(
                 f"Error parsing dimensions. "

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -546,8 +546,11 @@ class ManifoldMap(pn.viewable.Viewer):
     def _get_dim(self) -> AdDim:
         if self.color_by_dim == "obs":
             return A.obs[self.color_by]
+        # Color each observation by the gene's expression (a column of X, i.e. an
+        # obs-axis vector) so it matches the obsm-based x/y coordinates.
+        # Referencing the var axis here raises a DataError (obs vs var mismatch).
         if not self.var_reference:
-            return A.var.index
+            return A.X[:, self.color_by]
         var = self.adata.var.query(f'feature_name == "{self.color_by}"').index
         if len(var) > 1:
             msg = (
@@ -555,7 +558,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 f"for {self.color_by!r}."
             )
             raise RuntimeError(msg)
-        return A.var[self.color_by]
+        return A.X[:, var[0]]
 
     @staticmethod
     def get_reduction_label(dr_key: str) -> str:
@@ -628,9 +631,7 @@ class ManifoldMap(pn.viewable.Viewer):
         dr_label = self.get_reduction_label(dr_key)
 
         if not color_by:
-            return pmui.pane.Typography(
-                "Please select a variable to color by."
-            )
+            return pmui.pane.Typography("Please select a variable to color by.")
 
         if x_value == y_value:
             return pmui.pane.Typography(
@@ -753,24 +754,24 @@ class ManifoldMap(pn.viewable.Viewer):
             stylesheets=[stylesheet],
             sizing_mode="stretch_width",
         )
-        # Create widget box. Use a Bokeh-managed pn.Column (not pmui.Column) so
-        # the Bokeh ColorMap widget isn't a child of a React subtree -- React's
-        # reconciler was tearing out the ColorMap's DOM on mount. pmui widgets
-        # render fine as children of a pn.Column (React islands in a Bokeh layout).
+        # Create widget box in a Bokeh pn.Column so the Bokeh ColorMap isn't a
+        # child of a React subtree (React tears out its DOM on mount). The
+        # selectors use AutocompleteInput rather than Select: pmui's Select
+        # renders its dropdown in an MUI portal that mis-anchors to the top-left
+        # inside a Bokeh layout, whereas AutocompleteInput anchors correctly.
+        select_kw = dict(
+            min_characters=0,
+            search_strategy="includes",
+            case_sensitive=False,
+            description="",
+            sizing_mode="stretch_width",
+        )
         widgets = pn.Column(
-            pmui.widgets.Select.from_param(
-                self.param.reduction,
-                description="",
-                sizing_mode="stretch_width",
+            pmui.widgets.AutocompleteInput.from_param(
+                self.param.reduction, **select_kw
             ),
-            pmui.widgets.Select.from_param(
-                self.param.x_axis,
-                sizing_mode="stretch_width",
-            ),
-            pmui.widgets.Select.from_param(
-                self.param.y_axis,
-                sizing_mode="stretch_width",
-            ),
+            pmui.widgets.AutocompleteInput.from_param(self.param.x_axis, **select_kw),
+            pmui.widgets.AutocompleteInput.from_param(self.param.y_axis, **select_kw),
             color_by_dim,
             color,
             colormap,
@@ -786,9 +787,8 @@ class ManifoldMap(pn.viewable.Viewer):
                 visible=self.param._categorical,  # noqa: SLF001
             ),
             pmui.Details(
-                pmui.widgets.Select.from_param(
-                    self.param.legend_position,
-                    sizing_mode="stretch_width",
+                pmui.widgets.AutocompleteInput.from_param(
+                    self.param.legend_position, **select_kw
                 ),
                 pn.widgets.FloatSlider.from_param(
                     self.param.legend_alpha,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -755,7 +755,7 @@ class ManifoldMap(pn.viewable.Viewer):
         )
         color = pmui.widgets.AutocompleteInput.from_param(
             self.param.color_by,
-            name="",
+            label="",
             min_characters=0,
             search_strategy="includes",
             case_sensitive=False,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -518,10 +518,16 @@ class ManifoldMap(pn.viewable.Viewer):
         if old_is_categorical != self._categorical or not self.colormap:
             cmaps = CAT_CMAPS if self._categorical else CONT_CMAPS
             self.param.colormap.objects = cmaps
-            if self.colormap is None or self.colormap not in cmaps:
-                self.colormap = next(iter(cmaps.values()))
-            else:
-                self.colormap = cmaps[self.colormap]
+            # colormap holds a palette (list) once selected, or a name (str)
+            # initially; membership must test values, not (unhashable) keys.
+            current = (
+                cmaps.get(self.colormap)
+                if isinstance(self.colormap, str)
+                else self.colormap
+            )
+            if current not in cmaps.values():
+                current = next(iter(cmaps.values()))
+            self.colormap = current
         self._replot = True
 
     @hold()
@@ -621,6 +627,11 @@ class ManifoldMap(pn.viewable.Viewer):
         """
         dr_label = self.get_reduction_label(dr_key)
 
+        if not color_by:
+            return pmui.pane.Typography(
+                "Please select a variable to color by."
+            )
+
         if x_value == y_value:
             return pmui.pane.Typography(
                 "Please select different dimensions for X and Y axes."
@@ -696,6 +707,11 @@ class ManifoldMap(pn.viewable.Viewer):
             show_labels=self.show_labels,
             cmap=self.colormap,
         )
+        # create_plot returns a Typography pane (not a HoloViews element) for
+        # invalid axis selections, e.g. the transient x == y state while
+        # switching reductions; only apply opts to real hv elements.
+        if not isinstance(plot, hv.core.Dimensioned):
+            return plot
         return plot.opts(**self.plot_opts)
 
     def __panel__(self) -> pn.viewable.Viewable:
@@ -737,8 +753,11 @@ class ManifoldMap(pn.viewable.Viewer):
             stylesheets=[stylesheet],
             sizing_mode="stretch_width",
         )
-        # Create widget box
-        widgets = pmui.Column(
+        # Create widget box. Use a Bokeh-managed pn.Column (not pmui.Column) so
+        # the Bokeh ColorMap widget isn't a child of a React subtree -- React's
+        # reconciler was tearing out the ColorMap's DOM on mount. pmui widgets
+        # render fine as children of a pn.Column (React islands in a Bokeh layout).
+        widgets = pn.Column(
             pmui.widgets.Select.from_param(
                 self.param.reduction,
                 description="",
@@ -793,7 +812,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 visible=self.param._categorical,  # noqa: SLF001
             ),
             visible=self.param.show_widgets,
-            sx={"border": 1, "borderColor": "#e3e3e3", "borderRadius": 1},
+            styles={"border": "1px solid #e3e3e3", "border-radius": "4px"},
             sizing_mode="stretch_width",
             max_width=280,
             min_height=590,

--- a/src/hv_anndata/plotting/manifoldmap.py
+++ b/src/hv_anndata/plotting/manifoldmap.py
@@ -558,7 +558,7 @@ class ManifoldMap(pn.viewable.Viewer):
                 f"for {self.color_by!r}."
             )
             raise RuntimeError(msg)
-        return A.X[:, var[0]]
+        return A.var[self.color_by]
 
     @staticmethod
     def get_reduction_label(dr_key: str) -> str:

--- a/tests/plotting/test_manifold.py
+++ b/tests/plotting/test_manifold.py
@@ -159,6 +159,77 @@ def test_manifoldmap_get_dim_labels(sadata: ad.AnnData) -> None:
 
 
 @pytest.mark.usefixtures("bokeh_renderer")
+@pytest.mark.parametrize(
+    ("dr_label", "value", "expected"),
+    [
+        pytest.param("UMAP", "UMAP1", 0, id="first_dim"),
+        pytest.param("UMAP", "UMAP2", 1, id="second_dim"),
+        pytest.param("PCA", "PCA10", 9, id="multi_digit_dim"),
+    ],
+)
+def test_manifoldmap_dim_index(dr_label: str, value: str, expected: int) -> None:
+    assert ManifoldMap._dim_index(dr_label, value) == expected
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_create_plot_invalid_dimension_label(sadata: ad.AnnData) -> None:
+    """create_plot must still surface a parse-error pane via the shared _dim_index.
+
+    Matches its pre-refactor behavior.
+    """
+    mm = ManifoldMap(adata=sadata)
+
+    result = mm.create_plot(
+        dr_key="X_umap",
+        x_value="not_a_dim",
+        y_value="UMAP2",
+        color_by="cell_type",
+        datashade_value=False,
+        show_labels=False,
+        cmap=None,
+    )
+
+    assert isinstance(result, pmui.pane.Typography)
+    assert "Error parsing dimensions" in result.object
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_current_kdims_matches_active_axes(sadata: ad.AnnData) -> None:
+    mm = ManifoldMap(adata=sadata)
+
+    assert mm.current_kdims() == [
+        A.obsm["X_umap"][:, 0],
+        A.obsm["X_umap"][:, 1],
+    ]
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_current_kdims_tracks_swapped_axes(sadata: ad.AnnData) -> None:
+    """Swapping x_axis/y_axis must be reflected in kdim order, not just presence."""
+    mm = ManifoldMap(adata=sadata)
+
+    mm.x_axis, mm.y_axis = mm.y_axis, mm.x_axis
+
+    assert mm.current_kdims() == [
+        A.obsm["X_umap"][:, 1],
+        A.obsm["X_umap"][:, 0],
+    ]
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_manifoldmap_current_kdims_tracks_reduction_change(sadata: ad.AnnData) -> None:
+    """current_kdims must follow the active reduction, not the one at init."""
+    mm = ManifoldMap(adata=sadata)
+
+    mm.reduction = "X_pca"
+
+    assert mm.current_kdims() == [
+        A.obsm["X_pca"][:, 0],
+        A.obsm["X_pca"][:, 1],
+    ]
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
 @patch("hv_anndata.plotting.manifoldmap.create_manifoldmap_plot")
 def test_manifoldmap_create_plot(mock_cmp: Mock, sadata: ad.AnnData) -> None:
     mm = ManifoldMap(adata=sadata)


### PR DESCRIPTION
Builds on https://github.com/holoviz-topics/hv-anndata/pull/161

Expose the key dimensions the plot is currently displaying (active reduction
plus the selected x/y axes) so downstream code can build a `holoviews.Dataset`
that a selection expression emitted by the plot resolves against, instead of
assuming a fixed reduction or axis order.

Also factors the axis-label → index parsing into a shared `_dim_index` helper
so `current_kdims()` and `create_plot()` stay in sync.