### PR TITLE
Tweak dotmap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ lint.per-file-ignores."tests/*" = [
   "D",       # Missing docstrings in tests are OK
   "INP001",  # __init__.py should not be in tests
   "PLC1901", # comparing to empty string in tests is clearer
+  "PLC2701", # importing private helpers in tests is fine
   "PLR0917", # tests and fixures don’t have positional arguments
   "PLR2004", # magic-value-comparison
   "RUF018",  # assert with := is fine

--- a/src/hv_anndata/plotting/dotmap.py
+++ b/src/hv_anndata/plotting/dotmap.py
@@ -41,6 +41,9 @@ class _CreateDotmapPlotParams(TypedDict):
     standard_scale: NotRequired[Literal["var", "group"] | None]
     use_raw: NotRequired[bool | None]
     mean_only_expressed: NotRequired[bool]
+    responsive: NotRequired[bool]
+    width: NotRequired[int]
+    height: NotRequired[int]
 
 
 class _DotmapPlotParams(_CreateDotmapPlotParams):
@@ -61,6 +64,18 @@ _DEFAULT_EXPRESSION_CUTOFF = 0.0
 _DEFAULT_MEAN_ONLY_EXPRESSED = False
 _DEFAULT_MAX_DOT_SIZE = 20
 _DEFAULT_STANDARD_SCALE = None
+_DEFAULT_RESPONSIVE = True
+# Floor, not fixed, under stretch_both -- the plot stretches to its container
+# in both directions above this.
+_DEFAULT_WIDTH = 300
+_DEFAULT_HEIGHT = 300
+# BaseBar (what sizebar renders as) is shaped for a horizontal bar by default
+# (width=200, height=50). Its height accepts the literal string "max" -- the
+# SizeBar equivalent of the colorbar's "auto" -- so it fills its side panel
+# instead of floating as a small fixed box inside a panel sized to the (tall,
+# stretch_both) plot frame, which is what was leaving the empty space below.
+_DEFAULT_SIZEBAR_WIDTH = 150
+_DEFAULT_SIZEBAR_HEIGHT = 100
 
 
 def _prepare_data(  # ruff:ignore[complex-structure, too-many-branches, too-many-arguments, too-many-locals, too-many-statements]
@@ -230,6 +245,9 @@ def _get_opts(
     vdims: list[str | hv.Dimension] = _DEFAULT_VDIMS,
     marker_genes: dict[str, list[str]] | list[str] | None = None,
     max_dot_size: int = _DEFAULT_MAX_DOT_SIZE,
+    responsive: bool = _DEFAULT_RESPONSIVE,
+    width: int = _DEFAULT_WIDTH,
+    height: int = _DEFAULT_HEIGHT,
     plot_opts: Mapping[str, Any],
 ) -> dict[str, Any]:
     opts = dict(
@@ -241,6 +259,26 @@ def _get_opts(
     )
 
     radius_dim = hv.dim("percentage")
+    # Mirrors create_manifoldmap_plot: full stretch_both, width/height are
+    # floors. NOTE: an earlier attempt found that stretch_both left the
+    # sizebar's legend (dots + tick labels) unrendered until an external
+    # relayout (e.g. a zoom) -- looks like a HoloViews/Bokeh timing issue with
+    # side-panel annotations under stretch_both, not yet filed upstream.
+    # Pinning frame_width (stretch_height only) avoided it but gave up a
+    # width that fills the container; reverted to test whether the sizebar's
+    # now-explicit width/height/margin (below) are enough on their own.
+    if responsive:
+        sizing_opts = {
+            "responsive": True,
+            "min_width": width,
+            "min_height": height,
+        }
+    else:
+        sizing_opts = {
+            "responsive": False,
+            "frame_width": width,
+            "frame_height": height,
+        }
     match hv.Store.current_backend:
         case "matplotlib":
             backend_opts = {"s": radius_dim * max_dot_size}
@@ -251,7 +289,7 @@ def _get_opts(
             ):
                 hover_tooltips.remove("marker_cluster_name")
             backend_opts = {
-                "colorbar_position": "left",
+                "colorbar_position": "right",
                 "clabel": "Mean Expression",
                 "colorbar_opts": {
                     # Does not seem to work
@@ -261,18 +299,18 @@ def _get_opts(
                 "line_color": "k",
                 "tools": ["hover"],
                 "hover_tooltips": hover_tooltips,
-                "height": 500,
-                "responsive": "width",
-                # Saw layout issues with the dendrogram
-                # "min_height": 300,  # ruff:ignore[commented-out-code]
-                # "responsive": True,  # ruff:ignore[commented-out-code]
+                # NOTE: full responsive (stretch_both) was previously backed out
+                # here because of layout issues with the dendrogram.
+                **sizing_opts,
                 "radius": radius_dim / 100 / 2,
                 "sizebar": True,
-                "sizebar_location": "left",
+                "sizebar_location": "right",
                 "sizebar_orientation": "vertical",
                 "sizebar_opts": {
                     "title": "Fraction of\ncells (%)",
                     "title_standoff": 15,
+                    "width": _DEFAULT_SIZEBAR_WIDTH,
+                    "height": _DEFAULT_SIZEBAR_HEIGHT,
                     "formatter": CustomJSTickFormatter(
                         code="return Math.round(tick * 2 * 100, 2) + '%'"
                     ),
@@ -301,6 +339,9 @@ def create_dotmap_plot(  # ruff:ignore[too-many-arguments]
     mean_only_expressed: bool = _DEFAULT_MEAN_ONLY_EXPRESSED,
     standard_scale: Literal["var", "group"] | None = _DEFAULT_STANDARD_SCALE,
     max_dot_size: int = 20,
+    responsive: bool = _DEFAULT_RESPONSIVE,
+    width: int = _DEFAULT_WIDTH,
+    height: int = _DEFAULT_HEIGHT,
     plot_opts: Mapping[str, Any] | None = None,
 ) -> hv.Element:
     """Create a Dotmap plot from an AnnData object.
@@ -332,6 +373,13 @@ def create_dotmap_plot(  # ruff:ignore[too-many-arguments]
         gene, 'group' scales each cell type, by default None
     max_dot_size : int, optional
         Maximum size of the dots, by default 20
+    responsive : bool, optional
+        Whether to make the plot size-responsive, by default True. When True,
+        ``width`` and ``height`` act as minimums.
+    width : int, optional
+        Width of the plot, by default 300. The minimum width if responsive.
+    height : int, optional
+        Height of the plot, by default 300. The minimum height if responsive.
     plot_opts: dict, optional
         HoloViews plot options for the Points element.
 
@@ -361,6 +409,9 @@ def create_dotmap_plot(  # ruff:ignore[too-many-arguments]
         vdims=vdims,
         marker_genes=marker_genes,
         max_dot_size=max_dot_size,
+        responsive=responsive,
+        width=width,
+        height=height,
         plot_opts=plot_opts,
     )
     return plot.opts(**opts)
@@ -423,6 +474,23 @@ class DotmapParams(param.Parameterized):
     mean_only_expressed = param.Boolean(
         default=_DEFAULT_MEAN_ONLY_EXPRESSED,
         doc="If True, gene expression is averaged only over expressing cells.",
+    )
+
+    responsive = param.Boolean(
+        default=_DEFAULT_RESPONSIVE,
+        doc="""\
+        Whether to make the plot size-responsive. When True, width and height
+        act as minimums rather than fixed dimensions.""",
+    )
+
+    width = param.Integer(
+        default=_DEFAULT_WIDTH,
+        doc="Width of the plot; the minimum width when responsive.",
+    )
+
+    height = param.Integer(
+        default=_DEFAULT_HEIGHT,
+        doc="Height of the plot; the minimum height when responsive.",
     )
 
     plot_opts = param.Dict(doc="HoloViews plot options for the Points element.")

--- a/src/hv_anndata/plotting/dotmap.py
+++ b/src/hv_anndata/plotting/dotmap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from itertools import chain
 from typing import TYPE_CHECKING, TypedDict
@@ -12,7 +13,7 @@ import pandas as pd
 import panel as pn
 import panel_material_ui as pmui
 import param
-from bokeh.models import CustomJSTickFormatter
+from bokeh.models import CustomJSTickFormatter, FixedTicker
 from holoviews.core.operation import Operation
 from holoviews.core.overlay import Overlay
 from holoviews.selection import link_selections
@@ -70,12 +71,65 @@ _DEFAULT_RESPONSIVE = True
 _DEFAULT_WIDTH = 300
 _DEFAULT_HEIGHT = 300
 # BaseBar (what sizebar renders as) is shaped for a horizontal bar by default
-# (width=200, height=50). Its height accepts the literal string "max" -- the
-# SizeBar equivalent of the colorbar's "auto" -- so it fills its side panel
-# instead of floating as a small fixed box inside a panel sized to the (tall,
-# stretch_both) plot frame, which is what was leaving the empty space below.
+# (width=200, height=50). ``width`` is always the bar's *primary* axis, so for
+# our vertical bar it is the height on screen and ``height`` is the cross-axis
+# width; BaseBarView.initialize() swaps them into frame_height/frame_width.
 _DEFAULT_SIZEBAR_WIDTH = 150
 _DEFAULT_SIZEBAR_HEIGHT = 100
+# Percentage -> radius. Shared so the sizebar ticks, which are in radius space,
+# and the ``radius`` transform below cannot drift apart.
+_RADIUS_PER_PERCENT = 1 / 100 / 2
+# Reproduce bokeh's SizeBarView._paint and its AdaptiveTicker defaults; see
+# _sizebar_ticks. _SIZEBAR_MANTISSAS is AdaptiveTicker.extended_mantissas for
+# base=10, mantissas=[1, 2, 5]; its order matters, because ties go to the first
+# minimum as bokeh's argmin does.
+_SIZEBAR_EPS = 1e-6
+_SIZEBAR_DESIRED_TICKS = 5
+_SIZEBAR_MANTISSAS = (0.5, 1.0, 2.0, 5.0, 10.0)
+
+
+def _sizebar_ticks(percentages: pd.Series) -> list[float]:
+    """Compute the sizebar's tick locations.
+
+    Needed because bokeh's ``SizeBarView`` only computes its ticks in
+    ``_paint``, after the layout pass that sizes the panel holding the tick
+    labels, so with ``ticker="auto"`` that panel is measured against an empty
+    tick list. Bokeh usually recovers on a later pass -- a standalone plot looks
+    fine -- but inside ``pmui.Page`` it does not, and the sizebar renders dots
+    and tick marks with no labels until a zoom or resize. Whether that belongs
+    to bokeh's ordering or to panel's handling of the relayout bokeh asks for is
+    unresolved; supplying a ticker sidesteps it either way.
+
+    These have to be the values bokeh itself would pick, not rounder ones:
+    ``_paint`` positions the dots from its own AdaptiveTicker whatever this
+    ticker says, so a ticker that disagrees labels the wrong dots.
+
+    Returns
+    -------
+    list[float]
+        Tick locations in radius space, empty if there is no finite data.
+
+    """
+    lo, hi = float(percentages.min()), float(percentages.max())  # NaN-skipping
+    if not (math.isfinite(lo) and math.isfinite(hi)):
+        return []
+    r_min, r_max = lo * _RADIUS_PER_PERCENT, hi * _RADIUS_PER_PERCENT
+    if r_min == r_max:
+        low, high, desired = max(r_min - _SIZEBAR_EPS, 0.0), r_max + _SIZEBAR_EPS, 1
+    else:
+        low, high, desired = r_min, r_max, _SIZEBAR_DESIRED_TICKS
+    if low == 0:
+        low = high * _SIZEBAR_EPS
+    span = high - low
+    if span <= 0:
+        return []
+    magnitude = 10 ** math.floor(math.log10(span / desired))
+    interval = min(
+        (m * magnitude for m in _SIZEBAR_MANTISSAS),
+        key=lambda i: abs(desired - span / i),
+    )
+    factors = range(math.floor(low / interval), math.ceil(high / interval) + 1)
+    return [f * interval for f in factors if low <= f * interval <= high]
 
 
 def _prepare_data(  # ruff:ignore[complex-structure, too-many-branches, too-many-arguments, too-many-locals, too-many-statements]
@@ -239,7 +293,7 @@ def _prepare_data(  # ruff:ignore[complex-structure, too-many-branches, too-many
     return df
 
 
-def _get_opts(
+def _get_opts(  # ruff:ignore[too-many-arguments]
     *,
     kdims: list[str | hv.Dimension] = _DEFAULT_KDIMS,
     vdims: list[str | hv.Dimension] = _DEFAULT_VDIMS,
@@ -248,6 +302,7 @@ def _get_opts(
     responsive: bool = _DEFAULT_RESPONSIVE,
     width: int = _DEFAULT_WIDTH,
     height: int = _DEFAULT_HEIGHT,
+    percentages: pd.Series,
     plot_opts: Mapping[str, Any],
 ) -> dict[str, Any]:
     opts = dict(
@@ -260,13 +315,8 @@ def _get_opts(
 
     radius_dim = hv.dim("percentage")
     # Mirrors create_manifoldmap_plot: full stretch_both, width/height are
-    # floors. NOTE: an earlier attempt found that stretch_both left the
-    # sizebar's legend (dots + tick labels) unrendered until an external
-    # relayout (e.g. a zoom) -- looks like a HoloViews/Bokeh timing issue with
-    # side-panel annotations under stretch_both, not yet filed upstream.
-    # Pinning frame_width (stretch_height only) avoided it but gave up a
-    # width that fills the container; reverted to test whether the sizebar's
-    # now-explicit width/height/margin (below) are enough on their own.
+    # floors. The sizebar labels going missing here was not a stretch_both
+    # problem; see _sizebar_ticks.
     if responsive:
         sizing_opts = {
             "responsive": True,
@@ -302,7 +352,7 @@ def _get_opts(
                 # NOTE: full responsive (stretch_both) was previously backed out
                 # here because of layout issues with the dendrogram.
                 **sizing_opts,
-                "radius": radius_dim / 100 / 2,
+                "radius": radius_dim * _RADIUS_PER_PERCENT,
                 "sizebar": True,
                 "sizebar_location": "right",
                 "sizebar_orientation": "vertical",
@@ -311,8 +361,12 @@ def _get_opts(
                     "title_standoff": 15,
                     "width": _DEFAULT_SIZEBAR_WIDTH,
                     "height": _DEFAULT_SIZEBAR_HEIGHT,
+                    # Without this the labels never render; see _sizebar_ticks.
+                    "ticker": FixedTicker(ticks=_sizebar_ticks(percentages)),
+                    # Undo _RADIUS_PER_PERCENT to get back to a percentage,
+                    # then trim float noise without forcing a fixed precision.
                     "formatter": CustomJSTickFormatter(
-                        code="return Math.round(tick * 2 * 100, 2) + '%'"
+                        code="return (Math.round(tick * 200 * 100) / 100) + '%'"
                     ),
                 },
             }
@@ -412,6 +466,7 @@ def create_dotmap_plot(  # ruff:ignore[too-many-arguments]
         responsive=responsive,
         width=width,
         height=height,
+        percentages=data["percentage"],
         plot_opts=plot_opts,
     )
     return plot.opts(**opts)

--- a/tests/plotting/test_dotmap.py
+++ b/tests/plotting/test_dotmap.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import math
+
+import numpy as np
 import pandas as pd
 import pytest
 import scanpy as sc
 
 from hv_anndata import Dotmap
+from hv_anndata.plotting.dotmap import _RADIUS_PER_PERCENT, _sizebar_ticks
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -111,3 +115,74 @@ def test_dotmap_duplicate_genes_bokeh() -> None:
     )
     dotmap = dotmap_layout.plot()
     assert dotmap.data.shape == (20, 6)
+
+
+@pytest.mark.parametrize(
+    ("percentages", "expected"),
+    [
+        ([1.0, 12.0, 45.0, 80.0], [20.0, 40.0, 60.0, 80.0]),
+        ([5.0, 100.0], [20.0, 40.0, 60.0, 80.0, 100.0]),
+        ([0.2, 5.0], [1.0, 2.0, 3.0, 4.0, 5.0]),
+        ([37.0, 37.0], [37.0]),
+        ([42.0], [42.0]),
+        ([], []),
+        ([np.nan, np.nan], []),
+        ([np.nan, 10.0, 50.0], [10.0, 20.0, 30.0, 40.0, 50.0]),
+    ],
+    ids=[
+        "typical_spread",
+        "up_to_full_range",
+        "sub_percent_lower_bound",
+        "all_equal",
+        "single_value",
+        "empty",
+        "all_nan",
+        "some_nan",
+    ],
+)
+def test_sizebar_ticks(percentages: list[float], expected: list[float]) -> None:
+    """Ticks are the values bokeh's own AdaptiveTicker picks, in radius space.
+
+    They have to match, because SizeBarView._paint positions the legend dots
+    from its adaptive ticker regardless of the ticker we supply -- ticks that
+    disagree would label the wrong dots. Expectations here are in percent for
+    readability and converted to radius space to compare.
+    """
+    ticks = _sizebar_ticks(pd.Series(percentages, dtype=float))
+
+    assert ticks == pytest.approx([p * _RADIUS_PER_PERCENT for p in expected])
+
+
+@pytest.mark.parametrize(
+    "percentages",
+    [[1.0, 12.0, 45.0, 80.0], [0.2, 5.0], [5.0, 100.0], [0.0, 0.0], [0.0, 60.0]],
+    ids=["typical", "sub_percent", "full_range", "all_zero", "zero_lower_bound"],
+)
+def test_sizebar_ticks_within_glyph_radius_range(percentages: list[float]) -> None:
+    """Ticks must fall inside the bar's range, which is the glyph radius extent.
+
+    SizeBarView._paint derives that range from the actual min/max radius and
+    ``bounds`` can only narrow it, so a tick outside would be positioned off the
+    end of the bar. Zero is covered because it makes the lower bound degenerate.
+    """
+    series = pd.Series(percentages, dtype=float)
+    ticks = _sizebar_ticks(series)
+    r_min = series.min() * _RADIUS_PER_PERCENT
+    r_max = series.max() * _RADIUS_PER_PERCENT
+
+    assert all(math.isfinite(tick) for tick in ticks)
+    # An all-equal range is widened by an epsilon, so allow a tolerance.
+    assert all(r_min - 1e-6 <= tick <= r_max + 1e-6 for tick in ticks)
+
+
+@pytest.mark.usefixtures("bokeh_renderer")
+def test_dotmap_sizebar_has_explicit_ticker_bokeh() -> None:
+    """The sizebar needs a ticker up front or its tick labels never render."""
+    adata = sc.datasets.pbmc68k_reduced()
+    dotmap = Dotmap(
+        adata=adata, marker_genes={"A": ["C1QA", "PSAP"]}, groupby="bulk_labels"
+    ).plot()
+
+    sizebar_opts = dotmap.opts.get().kwargs["sizebar_opts"]
+
+    assert sizebar_opts["ticker"].ticks

--- a/tests/plotting/test_scanpy.py
+++ b/tests/plotting/test_scanpy.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 import scanpy as sc
-import scanpy.plotting._v2 as sc_pl_v2  # ruff: ignore[import-private-name]
+import scanpy.plotting._v2 as sc_pl_v2
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

Fixes responsive=True for sizebar.

Note, the underlying fault is bokeh's ordering or panel's handling of the relayout bokeh requests is still unresolved (couldn't reproduce solely with bokeh, only with panel).

```python
import holoviews as hv, panel as pn, panel_material_ui as pmui, scanpy as sc
from hv_anndata import Dotmap
hv.extension("bokeh")

adata = sc.datasets.pbmc68k_reduced()
dotmap = Dotmap(adata=adata, marker_genes={"A": ["C1QA", "PSAP", "CD79A"]}, groupby="bulk_labels")
pn.serve(pmui.Page(main=[dotmap]))
```

Before: the sizebar shows a column of dots and tick dashes with no "%" labels.
<img width="1346" height="896" alt="image" src="https://github.com/user-attachments/assets/7e3e815d-a5c7-4c68-ba2c-7aa964e8aed1" />


After:  the labels render next to the dots.
<img width="1411" height="809" alt="image" src="https://github.com/user-attachments/assets/9786680e-26f4-4ace-9e56-594f9828f43f" />

----------

Reproduce sizebar issue (note the right ticks):
<img width="1412" height="807" alt="image" src="https://github.com/user-attachments/assets/0380de8a-44f1-482b-9bed-85abbb75da96" />

```python
import panel as pn
import panel_material_ui as pmui
from bokeh.models import ColumnDataSource, FixedTicker, SizeBar
from bokeh.plotting import figure
 
RADII = [0.05, 0.10, 0.15, 0.20, 0.25]
 
 
def make_plot(title: str, **sizebar_kwargs: object) -> pn.pane.Bokeh:
    """Build a scatter of radial glyphs with a vertical SizeBar on the right."""
    source = ColumnDataSource(dict(x=list(range(1, 6)), y=[1] * 5, r=RADII))
    p = figure(title=title, sizing_mode="stretch_both", min_width=400, min_height=250)
    renderer = p.circle(x="x", y="y", radius="r", source=source, fill_alpha=0.5)
    p.add_layout(
        SizeBar(
            renderer=renderer,
            orientation="vertical",
            width=150,  # the bar's primary axis, i.e. its on-screen *height*
            height=100,  # the cross axis
            title="radius",
            **sizebar_kwargs,
        ),
        "right",
    )
    return pn.pane.Bokeh(p, sizing_mode="stretch_both")
 
 
pmui.Page(
    main=[
        pn.Column(
            make_plot("BROKEN  ticker='auto' (default): tick dashes, no labels"),
            make_plot(
                "WORKS  explicit FixedTicker: labels render",
                ticker=FixedTicker(ticks=RADII),
            ),
            sizing_mode="stretch_both",
        )
    ]
).servable()
```